### PR TITLE
feat: Add support_proposal instruction and tests

### DIFF
--- a/programs/package.json
+++ b/programs/package.json
@@ -17,5 +17,6 @@
     "prettier": "^2.6.2",
     "ts-mocha": "^10.0.0",
     "typescript": "^4.3.5"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/programs/programs/programs/src/error.rs
+++ b/programs/programs/programs/src/error.rs
@@ -17,10 +17,22 @@ pub enum ErrorCode {
     #[msg("Erreur personnalisée")]
     CustomError,
 
-    #[msg("Invalid epoch ID")]
+    #[msg("ID d'époque invalide")]
     InvalidEpochId,
 
-    #[msg("Epoch already inactive")]
+    #[msg("L'époque est déjà inactive")]
     EpochAlreadyInactive,
+
+    #[msg("La proposition n'est pas active")]
+    ProposalNotActive,
+
+    #[msg("La proposition n'appartient pas à l'époque spécifiée")]
+    ProposalEpochMismatch,
+
+    #[msg("Le montant doit être supérieur à zéro")]
+    AmountMustBeGreaterThanZero,
+
+    #[msg("Dépassement de capacité lors du calcul")]
+    Overflow,
 }
 

--- a/programs/programs/programs/src/instructions/mod.rs
+++ b/programs/programs/programs/src/instructions/mod.rs
@@ -4,12 +4,12 @@ pub mod end_epoch;
 pub mod get_proposal_details;
 pub mod initialize;
 pub mod start_epoch;
+pub mod support_proposal;
 
 pub use create_token_proposal::*;
 pub use start_epoch::*;
 pub use get_epoch_state::*;
 pub use end_epoch::*;
-pub use get_epoch_state::*;
 pub use get_proposal_details::*;
 pub use initialize::*;
-pub use start_epoch::*;
+pub use support_proposal::*;

--- a/programs/programs/programs/src/instructions/support_proposal.rs
+++ b/programs/programs/programs/src/instructions/support_proposal.rs
@@ -1,0 +1,96 @@
+use anchor_lang::prelude::*;
+use anchor_lang::system_program::{transfer, Transfer};
+// Importer les états et l'enum d'erreur global
+use crate::state::{EpochManagement, TokenProposal, UserProposalSupport, EpochStatus, ProposalStatus}; 
+use crate::error::ErrorCode; // Utiliser l'enum d'erreur global
+
+// Définition des comptes requis par l'instruction
+#[derive(Accounts)]
+#[instruction(amount: u64)]
+pub struct SupportProposal<'info> {
+    // Le compte qui paie et signe la transaction (l'utilisateur qui supporte)
+    #[account(mut)]
+    pub user: Signer<'info>,
+
+    // Le compte EpochManagement pour vérifier son statut
+    #[account(
+        // Contrainte : l'epoch doit être actif
+        // Note : Cette contrainte suppose que l'on peut facilement charger le compte Epoch lié à la proposition.
+        // Si EpochManagement n'est pas un PDA facilement dérivable ou si la vérification est plus complexe,
+        // elle devra être faite dans le handler.
+        constraint = epoch.status == EpochStatus::Active @ ErrorCode::EpochNotActive,
+        // Contrainte : l'epoch chargé doit correspondre à celui de la proposition
+        constraint = epoch.epoch_id == proposal.epoch_id @ ErrorCode::ProposalEpochMismatch
+    )]
+    pub epoch: Account<'info, EpochManagement>,
+
+    // Le compte TokenProposal qui reçoit le support
+    #[account(
+        mut, // Mutable car on va augmenter sol_raised et recevoir des SOL
+        // Contrainte : la proposition doit être active
+        constraint = proposal.status == ProposalStatus::Active @ ErrorCode::ProposalNotActive
+        // La contrainte `proposal.epoch_id == epoch.epoch_id` est déjà vérifiée ci-dessus
+    )]
+    pub proposal: Account<'info, TokenProposal>,
+
+    // Le nouveau compte UserProposalSupport à créer (PDA)
+    #[account(
+        init,
+        payer = user,
+        space = 8 + UserProposalSupport::INIT_SPACE, // 8 bytes discriminateur + taille struct
+        seeds = [
+            b"support",
+            proposal.epoch_id.to_le_bytes().as_ref(), // Seed par epoch_id de la proposition
+            user.key().as_ref(),                      // Seed par clé de l'utilisateur
+            proposal.key().as_ref()                   // Seed par clé de la proposition
+        ],
+        bump
+    )]
+    pub user_support: Account<'info, UserProposalSupport>,
+
+    // Le programme système, requis pour créer des comptes (init) et transférer des SOL
+    pub system_program: Program<'info, System>,
+}
+
+// Logique de l'instruction support_proposal
+pub fn handler(ctx: Context<SupportProposal>, amount: u64) -> Result<()> {
+    // Vérification de sécurité : s'assurer qu'un montant positif est envoyé
+    require!(amount > 0, ErrorCode::AmountMustBeGreaterThanZero);
+
+    // --- 1. Transférer les SOL de l'utilisateur vers le compte de la proposition ---
+    let cpi_context = CpiContext::new(
+        ctx.accounts.system_program.to_account_info(),
+        Transfer {
+            from: ctx.accounts.user.to_account_info(),
+            to: ctx.accounts.proposal.to_account_info(), // Envoyer directement au compte de la proposition
+        },
+    );
+    transfer(cpi_context, amount)?;
+
+    // --- 2. Mettre à jour les informations sur le compte TokenProposal ---
+    let proposal = &mut ctx.accounts.proposal;
+    // Utiliser checked_add pour éviter les overflows arithmétiques
+    proposal.sol_raised = proposal.sol_raised.checked_add(amount)
+        .ok_or_else(|| error!(ErrorCode::Overflow))?;
+    proposal.total_contributions = proposal.total_contributions.checked_add(1)
+        .ok_or_else(|| error!(ErrorCode::Overflow))?;
+
+    // --- 3. Initialiser le nouveau compte UserProposalSupport ---
+    let user_support = &mut ctx.accounts.user_support;
+    user_support.epoch_id = proposal.epoch_id; // Utiliser l'epoch_id de la proposition liée
+    user_support.user = ctx.accounts.user.key();
+    user_support.proposal = proposal.key();
+    user_support.amount = amount;
+    // Le bump est automatiquement géré par Anchor lors de `init` pour les versions >= 0.28
+
+    msg!("User {} supported proposal {} with {} lamports for epoch {}",
+        user_support.user,
+        user_support.proposal,
+        user_support.amount,
+        user_support.epoch_id
+    );
+
+    Ok(())
+}
+
+// L'enum local NosRugErrorCode est supprimé car nous utilisons maintenant ErrorCode de src/error.rs 

--- a/programs/programs/programs/src/lib.rs
+++ b/programs/programs/programs/src/lib.rs
@@ -19,7 +19,8 @@ pub mod programs {
         initialize::handler(_ctx)
     }
 
-    pub fn start_epoch(ctx: Context<StartEpoch>,
+    pub fn start_epoch(
+        ctx: Context<StartEpoch>,
         epoch_id: u64,
         start_time: i64,
         end_time: i64,
@@ -36,6 +37,10 @@ pub mod programs {
         lockup_period: i64,
     ) -> Result<()> {
        create_token_proposal::handler(ctx, token_name, token_symbol, total_supply, creator_allocation, lockup_period)
+    }
+
+    pub fn support_proposal(ctx: Context<SupportProposal>, amount: u64) -> Result<()> {
+        instructions::support_proposal::handler(ctx, amount)
     }
 
     pub fn get_epoch_state(

--- a/programs/yarn.lock
+++ b/programs/yarn.lock
@@ -50,7 +50,7 @@
   dependencies:
     "@noble/hashes" "1.7.1"
 
-"@noble/hashes@1.7.1", "@noble/hashes@^1.3.1", "@noble/hashes@^1.4.0":
+"@noble/hashes@^1.3.1", "@noble/hashes@^1.4.0", "@noble/hashes@1.7.1":
   version "1.7.1"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz"
   integrity sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==
@@ -154,14 +154,6 @@
   version "1.1.2"
   resolved "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
-
-JSONStream@^1.3.5:
-  version "1.3.5"
-  resolved "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz"
-  integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
-  dependencies:
-    jsonparse "^1.2.0"
-    through ">=2.2.7 <3"
 
 agentkeepalive@^4.5.0:
   version "4.6.0"
@@ -297,7 +289,7 @@ buffer-layout@^1.2.0, buffer-layout@^1.2.2:
   resolved "https://registry.npmjs.org/buffer-layout/-/buffer-layout-1.2.2.tgz"
   integrity sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA==
 
-buffer@6.0.3, buffer@^6.0.3, buffer@~6.0.3:
+buffer@^6.0.3, buffer@~6.0.3, buffer@6.0.3:
   version "6.0.3"
   resolved "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz"
   integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
@@ -427,15 +419,15 @@ delay@^5.0.0:
   resolved "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz"
   integrity sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==
 
-diff@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz"
-  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
-
 diff@^3.1.0:
   version "3.5.0"
   resolved "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+
+diff@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz"
+  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
 
 dot-case@^3.0.4:
   version "3.0.4"
@@ -524,7 +516,7 @@ fs.realpath@^1.0.0:
 
 fsevents@~2.3.2:
   version "2.3.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 get-caller-file@^2.0.5:
@@ -653,13 +645,13 @@ jayson@^4.1.1:
     "@types/connect" "^3.4.33"
     "@types/node" "^12.12.54"
     "@types/ws" "^7.4.4"
-    JSONStream "^1.3.5"
     commander "^2.20.3"
     delay "^5.0.0"
     es6-promisify "^5.0.0"
     eyes "^0.1.8"
     isomorphic-ws "^4.0.1"
     json-stringify-safe "^5.0.1"
+    JSONStream "^1.3.5"
     uuid "^8.3.2"
     ws "^7.5.10"
 
@@ -686,6 +678,14 @@ jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz"
   integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
+
+JSONStream@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz"
+  integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
+  dependencies:
+    jsonparse "^1.2.0"
+    through ">=2.2.7 <3"
 
 locate-path@^6.0.0:
   version "6.0.0"
@@ -721,17 +721,17 @@ make-error@^1.1.1:
   resolved "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
-minimatch@4.2.1:
-  version "4.2.1"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz"
-  integrity sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==
-  dependencies:
-    brace-expansion "^1.1.7"
-
 minimatch@^3.0.4:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@4.2.1:
+  version "4.2.1"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz"
+  integrity sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -747,7 +747,7 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.6"
 
-mocha@^9.0.3:
+"mocha@^3.X.X || ^4.X.X || ^5.X.X || ^6.X.X || ^7.X.X || ^8.X.X || ^9.X.X || ^10.X.X || ^11.X.X", mocha@^9.0.3:
   version "9.2.2"
   resolved "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz"
   integrity sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==
@@ -777,15 +777,15 @@ mocha@^9.0.3:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
+ms@^2.0.0, ms@2.1.3:
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
-
-ms@2.1.3, ms@^2.0.0:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 nanoid@3.3.1:
   version "3.3.1"
@@ -977,17 +977,17 @@ superstruct@^2.0.2:
   resolved "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz"
   integrity sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==
 
-supports-color@8.1.1:
-  version "8.1.1"
-  resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
-  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
-  dependencies:
-    has-flag "^4.0.0"
-
 supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
+
+supports-color@8.1.1:
+  version "8.1.1"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
 
@@ -1071,7 +1071,7 @@ undici-types@~6.21.0:
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
-utf-8-validate@^5.0.2:
+utf-8-validate@^5.0.2, utf-8-validate@>=5.0.2:
   version "5.0.10"
   resolved "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz"
   integrity sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==
@@ -1122,7 +1122,7 @@ wrappy@1:
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@^7.5.10:
+ws@*, ws@^7.5.10:
   version "7.5.10"
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
@@ -1137,7 +1137,7 @@ y18n@^5.0.5:
   resolved "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
-yargs-parser@20.2.4, yargs-parser@^20.2.2:
+yargs-parser@^20.2.2, yargs-parser@20.2.4:
   version "20.2.4"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz"
   integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==


### PR DESCRIPTION
Implement the support_proposal instruction to allow users to support a specific token proposal by sending SOL.

- Create support_proposal.rs instruction handler.

- Define SupportProposal accounts structure.

- Add UserProposalSupport account state.

- Update lib.rs, instructions/mod.rs, and error.rs.

- Add tests for support_proposal in proposal.test.ts.

Closes #20