### PR TITLE
feat(epoch): connect end epoch and list epoch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 test-ledger
 # IDL generated files
-front/context/idl/programs.json

--- a/front/app/[locale]/epoch/page.tsx
+++ b/front/app/[locale]/epoch/page.tsx
@@ -1,54 +1,45 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
-import { format } from "date-fns";
-import { enUS, fr } from "date-fns/locale";
+import EpochList from "@/components/epoch/EpochList";
+import { EpochState, useProgram } from "@/context/ProgramContext";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { useParams } from "next/navigation";
-import { useState } from "react";
-
-// TODO: Move types to shared types file
-type EpochStatus = "active" | "pending" | "ended";
-type Epoch = {
-  epoch_id: string;
-  start_time: Date;
-  end_time: Date | null;
-  status: EpochStatus;
-};
+import { useEffect, useState } from "react";
+import Loading from "../loading";
 
 export default function EpochPage() {
   const t = useTranslations("EpochManagement");
-  const { locale } = useParams();
+  const params = useParams();
+  const locale = params.locale as string | undefined;
+  const { getAllEpochs, isConnected, endEpoch } = useProgram();
+  const [epochs, setEpochs] = useState<EpochState[]>([]);
+  const [loading, setLoading] = useState(true);
 
-  // TODO: Replace with real data from Solana program (get_epoch_state())
-  const [epochs, setEpochs] = useState<Epoch[]>([
-    {
-      epoch_id: "epoch_1",
-      start_time: new Date("2025-04-02T09:15:45"),
-      end_time: null,
-      status: "active",
-    },
-    {
-      epoch_id: "epoch_2",
-      start_time: new Date("2025-04-01T09:15:45"),
-      end_time: new Date("2025-04-02T09:15:44"),
-      status: "ended",
-    },
-  ]);
+  useEffect(() => {
+    const fetchEpochs = async () => {
+      if (!isConnected) {
+        setLoading(false);
+        return;
+      }
 
-  // Format date based on user's locale
-  const formatDate = (date: Date) => {
-    return format(date, "PPpp", {
-      locale: locale === "fr" ? fr : enUS,
-    });
-  };
+      try {
+        const allEpochs = await getAllEpochs();
+        console.log("📝 Fetched epochs:", allEpochs);
+        setEpochs(allEpochs);
+      } catch (error) {
+        console.error("Failed to fetch epochs:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
 
-  // TODO: Connect these handlers to Solana program
-  const handleEndEpoch = async (epochId: string) => {
-    console.log("Ending epoch:", epochId);
-    // TODO: Call end_epoch instruction
-  };
+    fetchEpochs();
+  }, [getAllEpochs, isConnected]);
+
+  if (!isConnected || loading) {
+    return <Loading />;
+  }
 
   return (
     <div className="w-full max-w-4xl mx-auto p-4 space-y-6">
@@ -62,52 +53,19 @@ export default function EpochPage() {
         </Link>
       </div>
 
-      <div className="space-y-3 md:space-y-4">
-        {epochs.map((epoch) => (
-          <div
-            key={epoch.epoch_id}
-            className="bg-gray-900/50 p-3 md:p-4 rounded-lg border border-gray-800"
+      {epochs.length === 0 ? (
+        <div className="text-center space-y-4">
+          <p>{t("noEpochsMessage")}</p>
+          <Link
+            href={`/${locale}/epoch/create`}
+            className="inline-block px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg text-white transition-colors"
           >
-            <div className="flex flex-col md:flex-row md:items-center gap-3 md:gap-0 md:justify-between">
-              <div className="space-y-1 md:space-y-2">
-                <h3 className="text-base md:text-lg font-medium">
-                  {t("epochId")}: {epoch.epoch_id}
-                </h3>
-                <div className="flex flex-col text-xs md:text-sm text-gray-400">
-                  <p>
-                    {t("startTime")}: {formatDate(epoch.start_time)}
-                  </p>
-                  {epoch.end_time && (
-                    <p>
-                      {t("endTime")}: {formatDate(epoch.end_time)}
-                    </p>
-                  )}
-                </div>
-                <p
-                  className={`text-xs md:text-sm ${
-                    epoch.status === "active"
-                      ? "text-green-500"
-                      : epoch.status === "ended"
-                      ? "text-red-500"
-                      : "text-yellow-500"
-                  }`}
-                >
-                  {t("statusLabel")}: {t(`statusType.${epoch.status}`)}
-                </p>
-              </div>
-              {epoch.status === "active" && (
-                <Button
-                  onClick={() => handleEndEpoch(epoch.epoch_id)}
-                  variant="destructive"
-                  className="w-full md:w-auto bg-red-900 hover:bg-red-800 mt-2 md:mt-0"
-                >
-                  {t("endEpoch")}
-                </Button>
-              )}
-            </div>
-          </div>
-        ))}
-      </div>
+            {t("startFirstEpoch")}
+          </Link>
+        </div>
+      ) : (
+        <EpochList epochs={epochs} locale={locale} onEndEpoch={endEpoch} />
+      )}
     </div>
   );
 }

--- a/front/components/epoch/EpochList.tsx
+++ b/front/components/epoch/EpochList.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { EpochState, EpochStatus } from "@/context/ProgramContext";
+import { format } from "date-fns";
+import { enUS, fr } from "date-fns/locale";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useMemo, useState } from "react";
+
+type SortField = "epochId" | "startTime" | "endTime";
+type SortOrder = "asc" | "desc";
+
+function getStatusType(status: EpochStatus): string {
+  if ("active" in status) return "active";
+  if ("pending" in status) return "pending";
+  if ("closed" in status) return "closed";
+  return "unknown";
+}
+
+interface EpochListProps {
+  epochs: EpochState[];
+  locale: string | undefined;
+  onEndEpoch: (epochId: number) => Promise<void>;
+}
+
+export default function EpochList({
+  epochs,
+  locale,
+  onEndEpoch,
+}: EpochListProps) {
+  const t = useTranslations("EpochManagement");
+  const [sortField, setSortField] = useState<SortField>("epochId");
+  const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
+  const [loading, setLoading] = useState<number | null>(null);
+
+  const sortedEpochs = useMemo(() => {
+    return [...epochs].sort((a, b) => {
+      const multiplier = sortOrder === "asc" ? 1 : -1;
+      const fieldA = sortField === "epochId" ? parseInt(a[sortField]) : a[sortField];
+      const fieldB = sortField === "epochId" ? parseInt(b[sortField]) : b[sortField];
+      return (fieldA - fieldB) * multiplier;
+    });
+  }, [epochs, sortField, sortOrder]);
+
+  const toggleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortOrder(sortOrder === "asc" ? "desc" : "asc");
+    } else {
+      setSortField(field);
+      setSortOrder("desc");
+    }
+  };
+
+  const formatDate = (timestamp: number) => {
+    return format(new Date(timestamp * 1000), "PPpp", {
+      locale: locale === "fr" ? fr : enUS,
+    });
+  };
+
+  const handleEndEpoch = async (epochId: string) => {
+    try {
+      setLoading(parseInt(epochId));
+      await onEndEpoch(parseInt(epochId));
+    } catch (error) {
+      console.error("Failed to end epoch:", error);
+    } finally {
+      setLoading(null);
+    }
+  };
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-2 mb-4">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => toggleSort("epochId")}
+          className="flex items-center gap-1"
+        >
+          {t("sortById")}
+          {sortField === "epochId" &&
+            (sortOrder === "asc" ? (
+              <ChevronUp className="h-4 w-4" />
+            ) : (
+              <ChevronDown className="h-4 w-4" />
+            ))}
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => toggleSort("startTime")}
+          className="flex items-center gap-1"
+        >
+          {t("sortByStart")}
+          {sortField === "startTime" &&
+            (sortOrder === "asc" ? (
+              <ChevronUp className="h-4 w-4" />
+            ) : (
+              <ChevronDown className="h-4 w-4" />
+            ))}
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => toggleSort("endTime")}
+          className="flex items-center gap-1"
+        >
+          {t("sortByEnd")}
+          {sortField === "endTime" &&
+            (sortOrder === "asc" ? (
+              <ChevronUp className="h-4 w-4" />
+            ) : (
+              <ChevronDown className="h-4 w-4" />
+            ))}
+        </Button>
+      </div>
+
+      <div className="space-y-3 md:space-y-4">
+        {sortedEpochs.map((epoch) => (
+          <div
+            key={epoch.epochId}
+            className="bg-gray-900/50 p-3 md:p-4 rounded-lg border border-gray-800"
+          >
+            <div className="flex flex-col md:flex-row md:items-center gap-3 md:gap-0 md:justify-between">
+              <div className="space-y-1 md:space-y-2">
+                <h3 className="text-base md:text-lg font-medium">
+                  {t("epochId")}: {epoch.epochId}
+                </h3>
+                <div className="flex flex-col text-xs md:text-sm text-gray-400">
+                  <p>
+                    {t("startTime")}: {formatDate(epoch.startTime)}
+                  </p>
+                  <p>
+                    {t("endTime")}: {formatDate(epoch.endTime)}
+                  </p>
+                </div>
+                <p
+                  className={`text-xs md:text-sm ${
+                    "active" in epoch.status
+                      ? "text-green-500"
+                      : "closed" in epoch.status
+                      ? "text-red-500"
+                      : "text-yellow-500"
+                  }`}
+                >
+                  {t("statusLabel")}:{" "}
+                  {t(`statusType.${getStatusType(epoch.status)}`)}
+                </p>
+              </div>
+              {"active" in epoch.status && (
+                <Button
+                  variant="destructive"
+                  className="w-full md:w-auto bg-red-900 hover:bg-red-800 mt-2 md:mt-0"
+                  onClick={() => handleEndEpoch(epoch.epochId)}
+                  disabled={loading === parseInt(epoch.epochId)}
+                >
+                  {loading === parseInt(epoch.epochId) ? (
+                    <span className="flex items-center gap-2">
+                      <span className="animate-spin">⏳</span>{" "}
+                      {t("endingEpoch")}
+                    </span>
+                  ) : (
+                    t("endEpoch")
+                  )}
+                </Button>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/front/context/ProgramContext.tsx
+++ b/front/context/ProgramContext.tsx
@@ -124,7 +124,7 @@ export function ProgramProvider({ children }: { children: React.ReactNode }) {
       console.log("📝 Available methods:", Object.keys(program.methods));
 
       // Start the epoch
-      const tx = await program.methods
+      const tx = await (program as Program).methods
         .startEpoch(
           new BN(epochId),
           new BN(startTimestamp),
@@ -193,7 +193,7 @@ export function ProgramProvider({ children }: { children: React.ReactNode }) {
       console.log("🔑 Ending epoch with PDA:", epochManagementPDA.toBase58());
 
       // End the epoch
-      const tx = await program.methods
+      const tx = await (program as Program).methods
         .endEpoch(new BN(epochId))
         .accounts({
           epoch_management: epochManagementPDA,

--- a/front/context/ProgramContext.tsx
+++ b/front/context/ProgramContext.tsx
@@ -5,9 +5,24 @@ import { BN, Program } from "@coral-xyz/anchor";
 import { useAnchorWallet, useConnection } from "@solana/wallet-adapter-react";
 import { LAMPORTS_PER_SOL, PublicKey, SystemProgram } from "@solana/web3.js";
 import { createContext, useContext, useMemo, useState } from "react";
+import { Programs } from "./types/programs";
 
-// Define program type
-type ProgramType = Program<any>;
+export type { Programs };
+
+type ProgramType = Program<Programs>;
+
+export type EpochStatus =
+  | Programs["types"][2]["type"]["variants"][0]
+  | Programs["types"][2]["type"]["variants"][1]
+  | Programs["types"][2]["type"]["variants"][2];
+
+export type EpochState = {
+  epochId: string;
+  startTime: number;
+  endTime: number;
+  status: EpochStatus;
+  publicKey: PublicKey;
+};
 
 type ProgramContextType = {
   program: ProgramType | null;
@@ -21,6 +36,9 @@ type ProgramContextType = {
     startTime: string,
     endTime: string
   ) => Promise<void>;
+  getEpochState: (epochId: number) => Promise<EpochState | null>;
+  getAllEpochs: () => Promise<EpochState[]>;
+  endEpoch: (epochId: number) => Promise<void>;
 };
 
 const ProgramContext = createContext<ProgramContextType | null>(null);
@@ -40,6 +58,36 @@ export function ProgramProvider({ children }: { children: React.ReactNode }) {
     return null;
   }, [connection, wallet]);
 
+  const getEpochState = async (epochId: number): Promise<EpochState | null> => {
+    if (!program) return null;
+
+    try {
+      const [epochManagementPDA] = PublicKey.findProgramAddressSync(
+        [Buffer.from("epoch"), new BN(epochId).toArrayLike(Buffer, "le", 8)],
+        program.programId
+      );
+
+      const epochAccount = await (
+        program as ProgramType
+      ).account.epochManagement.fetch(epochManagementPDA);
+
+      return {
+        epochId: epochAccount.epochId.toString(),
+        startTime: epochAccount.startTime.toNumber(),
+        endTime: epochAccount.endTime.toNumber(),
+        status: epochAccount.status,
+        publicKey: epochManagementPDA,
+      };
+    } catch (err: any) {
+      // If account not found, return null
+      if (err.message.includes("Account does not exist")) {
+        return null;
+      }
+      console.error("❌ Error getting epoch state:", err);
+      return null;
+    }
+  };
+
   const startEpoch = async (
     epochId: number,
     startTime: string,
@@ -51,7 +99,7 @@ export function ProgramProvider({ children }: { children: React.ReactNode }) {
     }
 
     try {
-      // Check balance first
+      // Check wallet balance and request airdrop if needed
       const balance = await connection.getBalance(wallet.publicKey);
       if (balance < LAMPORTS_PER_SOL) {
         console.log("💰 Requesting airdrop for transaction fees...");
@@ -62,23 +110,20 @@ export function ProgramProvider({ children }: { children: React.ReactNode }) {
         await connection.confirmTransaction(signature);
       }
 
-      console.log("🚀 Starting epoch with params:", {
-        epochId,
-        startTime,
-        endTime,
-      });
-
+      // Convert dates to timestamps
       const startTimestamp = Math.floor(new Date(startTime).getTime() / 1000);
       const endTimestamp = Math.floor(new Date(endTime).getTime() / 1000);
 
+      // Generate PDA for epoch management account
       const [epochManagementPDA] = PublicKey.findProgramAddressSync(
-        [Buffer.from("epoch"), Buffer.from(epochId.toString())],
+        [Buffer.from("epoch"), new BN(epochId).toArrayLike(Buffer, "le", 8)],
         program.programId
       );
 
-      // Log les méthodes disponibles pour debug
+      // Log available methods for debugging
       console.log("📝 Available methods:", Object.keys(program.methods));
 
+      // Start the epoch
       const tx = await program.methods
         .startEpoch(
           new BN(epochId),
@@ -101,6 +146,74 @@ export function ProgramProvider({ children }: { children: React.ReactNode }) {
     }
   };
 
+  const getAllEpochs = async (): Promise<EpochState[]> => {
+    if (!program) return [];
+
+    try {
+      const allEpochs = await (
+        program as ProgramType
+      ).account.epochManagement.all();
+
+      return allEpochs.map((epoch) => ({
+        epochId: epoch.account.epochId.toString(),
+        startTime: epoch.account.startTime.toNumber(),
+        endTime: epoch.account.endTime.toNumber(),
+        status: epoch.account.status,
+        publicKey: epoch.publicKey,
+      }));
+    } catch (err: any) {
+      console.error("❌ Error fetching epochs:", err);
+      return [];
+    }
+  };
+
+  const endEpoch = async (epochId: number) => {
+    if (!program || !isConnected || !wallet) {
+      console.error("❌ Program not initialized or wallet not connected");
+      throw new Error("Please connect your wallet first");
+    }
+
+    try {
+      // Check if epoch exists and is active
+      const epochState = await getEpochState(epochId);
+      if (!epochState) {
+        throw new Error("Epoch not found");
+      }
+
+      if (!("active" in epochState.status)) {
+        throw new Error("Epoch is not active");
+      }
+
+      // Generate PDA with same format as getEpochState
+      const [epochManagementPDA] = PublicKey.findProgramAddressSync(
+        [Buffer.from("epoch"), new BN(epochId).toArrayLike(Buffer, "le", 8)],
+        program.programId
+      );
+
+      console.log("🔑 Ending epoch with PDA:", epochManagementPDA.toBase58());
+
+      // End the epoch
+      const tx = await program.methods
+        .endEpoch(new BN(epochId))
+        .accounts({
+          epoch_management: epochManagementPDA,
+          authority: wallet.publicKey,
+          system_program: SystemProgram.programId,
+        })
+        .rpc();
+
+      console.log("✅ Epoch ended:", tx);
+      setSuccess("Epoch ended successfully");
+
+      // Refresh epochs list
+      await getAllEpochs();
+    } catch (err: any) {
+      console.error("❌ Error ending epoch:", err);
+      setError(err.message);
+      throw err;
+    }
+  };
+
   const value = useMemo(
     () => ({
       program,
@@ -110,6 +223,9 @@ export function ProgramProvider({ children }: { children: React.ReactNode }) {
       setError,
       setSuccess,
       startEpoch,
+      getEpochState,
+      getAllEpochs,
+      endEpoch,
     }),
     [program, isConnected, error, success]
   );

--- a/front/context/idl/programs.json
+++ b/front/context/idl/programs.json
@@ -1,0 +1,566 @@
+{
+  "address": "4ExYLppEEnLNgcV7xRwJKAKnCBSDpdF9DpphxS63kHJs",
+  "metadata": {
+    "name": "programs",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "Created with Anchor"
+  },
+  "instructions": [
+    {
+      "name": "create_proposal",
+      "discriminator": [
+        132,
+        116,
+        68,
+        174,
+        216,
+        160,
+        198,
+        22
+      ],
+      "accounts": [
+        {
+          "name": "creator",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_proposal",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  112,
+                  111,
+                  115,
+                  97,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "creator"
+              },
+              {
+                "kind": "account",
+                "path": "epoch.epoch_id",
+                "account": "EpochManagement"
+              },
+              {
+                "kind": "arg",
+                "path": "token_name"
+              }
+            ]
+          }
+        },
+        {
+          "name": "epoch"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "token_name",
+          "type": "string"
+        },
+        {
+          "name": "token_symbol",
+          "type": "string"
+        },
+        {
+          "name": "total_supply",
+          "type": "u64"
+        },
+        {
+          "name": "creator_allocation",
+          "type": "u8"
+        },
+        {
+          "name": "lockup_period",
+          "type": "i64"
+        }
+      ]
+    },
+    {
+      "name": "end_epoch",
+      "discriminator": [
+        195,
+        166,
+        17,
+        226,
+        105,
+        210,
+        96,
+        216
+      ],
+      "accounts": [
+        {
+          "name": "epoch_management",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  112,
+                  111,
+                  99,
+                  104
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "epoch_id"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "epoch_id",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "get_epoch_state",
+      "discriminator": [
+        143,
+        2,
+        34,
+        250,
+        77,
+        45,
+        31,
+        154
+      ],
+      "accounts": [
+        {
+          "name": "epoch_management"
+        }
+      ],
+      "args": [
+        {
+          "name": "epoch_id",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "get_proposal_details",
+      "discriminator": [
+        236,
+        135,
+        27,
+        97,
+        207,
+        192,
+        173,
+        128
+      ],
+      "accounts": [
+        {
+          "name": "proposal",
+          "writable": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "proposal_id",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "initialize",
+      "discriminator": [
+        175,
+        175,
+        109,
+        31,
+        13,
+        152,
+        155,
+        237
+      ],
+      "accounts": [],
+      "args": []
+    },
+    {
+      "name": "start_epoch",
+      "discriminator": [
+        204,
+        248,
+        232,
+        82,
+        251,
+        45,
+        164,
+        113
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "epoch_management",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  112,
+                  111,
+                  99,
+                  104
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "epoch_id"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "epoch_id",
+          "type": "u64"
+        },
+        {
+          "name": "start_time",
+          "type": "i64"
+        },
+        {
+          "name": "end_time",
+          "type": "i64"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "EpochManagement",
+      "discriminator": [
+        182,
+        45,
+        141,
+        215,
+        61,
+        70,
+        49,
+        206
+      ]
+    },
+    {
+      "name": "TokenProposal",
+      "discriminator": [
+        192,
+        42,
+        4,
+        79,
+        215,
+        17,
+        144,
+        39
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "EpochEnded",
+      "discriminator": [
+        111,
+        40,
+        102,
+        241,
+        173,
+        233,
+        164,
+        252
+      ]
+    },
+    {
+      "name": "ProposalDetailsRetrieved",
+      "discriminator": [
+        81,
+        200,
+        254,
+        55,
+        73,
+        7,
+        79,
+        217
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "CreatorAllocationTooHigh",
+      "msg": "L'allocation du créateur ne peut pas dépasser 10%"
+    },
+    {
+      "code": 6001,
+      "name": "EpochNotActive",
+      "msg": "L'époque n'est pas active"
+    },
+    {
+      "code": 6002,
+      "name": "InvalidEpochTimeRange",
+      "msg": "La plage de temps de l'époque est invalide"
+    },
+    {
+      "code": 6003,
+      "name": "EpochNotFound",
+      "msg": "L'époque n'a pas été trouvée"
+    },
+    {
+      "code": 6004,
+      "name": "CustomError",
+      "msg": "Erreur personnalisée"
+    },
+    {
+      "code": 6005,
+      "name": "InvalidEpochId",
+      "msg": "Invalid epoch ID"
+    },
+    {
+      "code": 6006,
+      "name": "EpochAlreadyInactive",
+      "msg": "Epoch already inactive"
+    }
+  ],
+  "types": [
+    {
+      "name": "EpochEnded",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "epoch_id",
+            "type": "u64"
+          },
+          {
+            "name": "ended_at",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EpochManagement",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "epoch_id",
+            "type": "u64"
+          },
+          {
+            "name": "start_time",
+            "type": "i64"
+          },
+          {
+            "name": "end_time",
+            "type": "i64"
+          },
+          {
+            "name": "status",
+            "type": {
+              "defined": {
+                "name": "EpochStatus"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "EpochStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Active"
+          },
+          {
+            "name": "Pending"
+          },
+          {
+            "name": "Closed"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProposalDetailsRetrieved",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "epoch_id",
+            "type": "u64"
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_name",
+            "type": "string"
+          },
+          {
+            "name": "token_symbol",
+            "type": "string"
+          },
+          {
+            "name": "total_supply",
+            "type": "u64"
+          },
+          {
+            "name": "creator_allocation",
+            "type": "u8"
+          },
+          {
+            "name": "supporter_allocation",
+            "type": "u8"
+          },
+          {
+            "name": "sol_raised",
+            "type": "u64"
+          },
+          {
+            "name": "total_contributions",
+            "type": "u64"
+          },
+          {
+            "name": "lockup_period",
+            "type": "i64"
+          },
+          {
+            "name": "status",
+            "type": {
+              "defined": {
+                "name": "ProposalStatus"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProposalStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Active"
+          },
+          {
+            "name": "Validated"
+          },
+          {
+            "name": "Rejected"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenProposal",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "epoch_id",
+            "type": "u64"
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_name",
+            "type": "string"
+          },
+          {
+            "name": "token_symbol",
+            "type": "string"
+          },
+          {
+            "name": "total_supply",
+            "type": "u64"
+          },
+          {
+            "name": "creator_allocation",
+            "type": "u8"
+          },
+          {
+            "name": "supporter_allocation",
+            "type": "u8"
+          },
+          {
+            "name": "sol_raised",
+            "type": "u64"
+          },
+          {
+            "name": "total_contributions",
+            "type": "u64"
+          },
+          {
+            "name": "lockup_period",
+            "type": "i64"
+          },
+          {
+            "name": "status",
+            "type": {
+              "defined": {
+                "name": "ProposalStatus"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "constants": [
+    {
+      "name": "SEED",
+      "type": "string",
+      "value": "\"anchor\""
+    }
+  ]
+}

--- a/front/context/types/programs.ts
+++ b/front/context/types/programs.ts
@@ -1,0 +1,572 @@
+/**
+ * Program IDL in camelCase format in order to be used in JS/TS.
+ *
+ * Note that this is only a type helper and is not the actual IDL. The original
+ * IDL can be found at `target/idl/programs.json`.
+ */
+export type Programs = {
+  "address": "4ExYLppEEnLNgcV7xRwJKAKnCBSDpdF9DpphxS63kHJs",
+  "metadata": {
+    "name": "programs",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "Created with Anchor"
+  },
+  "instructions": [
+    {
+      "name": "createProposal",
+      "discriminator": [
+        132,
+        116,
+        68,
+        174,
+        216,
+        160,
+        198,
+        22
+      ],
+      "accounts": [
+        {
+          "name": "creator",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "tokenProposal",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  112,
+                  111,
+                  115,
+                  97,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "creator"
+              },
+              {
+                "kind": "account",
+                "path": "epoch.epoch_id",
+                "account": "epochManagement"
+              },
+              {
+                "kind": "arg",
+                "path": "tokenName"
+              }
+            ]
+          }
+        },
+        {
+          "name": "epoch"
+        },
+        {
+          "name": "systemProgram",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "tokenName",
+          "type": "string"
+        },
+        {
+          "name": "tokenSymbol",
+          "type": "string"
+        },
+        {
+          "name": "totalSupply",
+          "type": "u64"
+        },
+        {
+          "name": "creatorAllocation",
+          "type": "u8"
+        },
+        {
+          "name": "lockupPeriod",
+          "type": "i64"
+        }
+      ]
+    },
+    {
+      "name": "endEpoch",
+      "discriminator": [
+        195,
+        166,
+        17,
+        226,
+        105,
+        210,
+        96,
+        216
+      ],
+      "accounts": [
+        {
+          "name": "epochManagement",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  112,
+                  111,
+                  99,
+                  104
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "epochId"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "systemProgram",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "epochId",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "getEpochState",
+      "discriminator": [
+        143,
+        2,
+        34,
+        250,
+        77,
+        45,
+        31,
+        154
+      ],
+      "accounts": [
+        {
+          "name": "epochManagement"
+        }
+      ],
+      "args": [
+        {
+          "name": "epochId",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "getProposalDetails",
+      "discriminator": [
+        236,
+        135,
+        27,
+        97,
+        207,
+        192,
+        173,
+        128
+      ],
+      "accounts": [
+        {
+          "name": "proposal",
+          "writable": true
+        },
+        {
+          "name": "systemProgram",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "proposalId",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "initialize",
+      "discriminator": [
+        175,
+        175,
+        109,
+        31,
+        13,
+        152,
+        155,
+        237
+      ],
+      "accounts": [],
+      "args": []
+    },
+    {
+      "name": "startEpoch",
+      "discriminator": [
+        204,
+        248,
+        232,
+        82,
+        251,
+        45,
+        164,
+        113
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "epochManagement",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  112,
+                  111,
+                  99,
+                  104
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "epochId"
+              }
+            ]
+          }
+        },
+        {
+          "name": "systemProgram",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "epochId",
+          "type": "u64"
+        },
+        {
+          "name": "startTime",
+          "type": "i64"
+        },
+        {
+          "name": "endTime",
+          "type": "i64"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "epochManagement",
+      "discriminator": [
+        182,
+        45,
+        141,
+        215,
+        61,
+        70,
+        49,
+        206
+      ]
+    },
+    {
+      "name": "tokenProposal",
+      "discriminator": [
+        192,
+        42,
+        4,
+        79,
+        215,
+        17,
+        144,
+        39
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "epochEnded",
+      "discriminator": [
+        111,
+        40,
+        102,
+        241,
+        173,
+        233,
+        164,
+        252
+      ]
+    },
+    {
+      "name": "proposalDetailsRetrieved",
+      "discriminator": [
+        81,
+        200,
+        254,
+        55,
+        73,
+        7,
+        79,
+        217
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "creatorAllocationTooHigh",
+      "msg": "L'allocation du créateur ne peut pas dépasser 10%"
+    },
+    {
+      "code": 6001,
+      "name": "epochNotActive",
+      "msg": "L'époque n'est pas active"
+    },
+    {
+      "code": 6002,
+      "name": "invalidEpochTimeRange",
+      "msg": "La plage de temps de l'époque est invalide"
+    },
+    {
+      "code": 6003,
+      "name": "epochNotFound",
+      "msg": "L'époque n'a pas été trouvée"
+    },
+    {
+      "code": 6004,
+      "name": "customError",
+      "msg": "Erreur personnalisée"
+    },
+    {
+      "code": 6005,
+      "name": "invalidEpochId",
+      "msg": "Invalid epoch ID"
+    },
+    {
+      "code": 6006,
+      "name": "epochAlreadyInactive",
+      "msg": "Epoch already inactive"
+    }
+  ],
+  "types": [
+    {
+      "name": "epochEnded",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "epochId",
+            "type": "u64"
+          },
+          {
+            "name": "endedAt",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "epochManagement",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "epochId",
+            "type": "u64"
+          },
+          {
+            "name": "startTime",
+            "type": "i64"
+          },
+          {
+            "name": "endTime",
+            "type": "i64"
+          },
+          {
+            "name": "status",
+            "type": {
+              "defined": {
+                "name": "epochStatus"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "epochStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "active"
+          },
+          {
+            "name": "pending"
+          },
+          {
+            "name": "closed"
+          }
+        ]
+      }
+    },
+    {
+      "name": "proposalDetailsRetrieved",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "epochId",
+            "type": "u64"
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "tokenName",
+            "type": "string"
+          },
+          {
+            "name": "tokenSymbol",
+            "type": "string"
+          },
+          {
+            "name": "totalSupply",
+            "type": "u64"
+          },
+          {
+            "name": "creatorAllocation",
+            "type": "u8"
+          },
+          {
+            "name": "supporterAllocation",
+            "type": "u8"
+          },
+          {
+            "name": "solRaised",
+            "type": "u64"
+          },
+          {
+            "name": "totalContributions",
+            "type": "u64"
+          },
+          {
+            "name": "lockupPeriod",
+            "type": "i64"
+          },
+          {
+            "name": "status",
+            "type": {
+              "defined": {
+                "name": "proposalStatus"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "proposalStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "active"
+          },
+          {
+            "name": "validated"
+          },
+          {
+            "name": "rejected"
+          }
+        ]
+      }
+    },
+    {
+      "name": "tokenProposal",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "epochId",
+            "type": "u64"
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "tokenName",
+            "type": "string"
+          },
+          {
+            "name": "tokenSymbol",
+            "type": "string"
+          },
+          {
+            "name": "totalSupply",
+            "type": "u64"
+          },
+          {
+            "name": "creatorAllocation",
+            "type": "u8"
+          },
+          {
+            "name": "supporterAllocation",
+            "type": "u8"
+          },
+          {
+            "name": "solRaised",
+            "type": "u64"
+          },
+          {
+            "name": "totalContributions",
+            "type": "u64"
+          },
+          {
+            "name": "lockupPeriod",
+            "type": "i64"
+          },
+          {
+            "name": "status",
+            "type": {
+              "defined": {
+                "name": "proposalStatus"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "constants": [
+    {
+      "name": "seed",
+      "type": "string",
+      "value": "\"anchor\""
+    }
+  ]
+};

--- a/front/messages/en.json
+++ b/front/messages/en.json
@@ -45,8 +45,19 @@
     "statusType": {
       "active": "Active",
       "pending": "Pending",
-      "ended": "Ended"
-    }
+      "closed": "Closed"
+    },
+    "loading": "Loading epochs...",
+    "connectWalletMessage": "Please connect your wallet to view epochs",
+    "connectWallet": "Connect Wallet",
+    "noEpochsMessage": "No epochs found. Start your first epoch to begin!",
+    "startFirstEpoch": "Start First Epoch",
+    "sortById": "Sort by ID",
+    "sortByStart": "Sort by Start Date",
+    "sortByEnd": "Sort by End Date",
+    "endingEpoch": "Ending epoch...",
+    "endEpochSuccess": "Epoch ended successfully",
+    "endEpochError": "Failed to end epoch"
   },
   "Home": {
     "currentEpoch": "Current Epoch",

--- a/front/messages/fr.json
+++ b/front/messages/fr.json
@@ -45,8 +45,19 @@
     "statusType": {
       "active": "Actif",
       "pending": "En attente",
-      "ended": "Terminé"
-    }
+      "closed": "Terminé"
+    },
+    "loading": "Chargement des epochs...",
+    "connectWalletMessage": "Veuillez connecter votre wallet pour voir les epochs",
+    "connectWallet": "Connecter le Wallet",
+    "noEpochsMessage": "Aucun epoch trouvé. Démarrez votre premier epoch pour commencer !",
+    "startFirstEpoch": "Démarrer le Premier Epoch",
+    "sortById": "Trier par ID",
+    "sortByStart": "Trier par date de début",
+    "sortByEnd": "Trier par date de fin",
+    "endingEpoch": "Fin de l'epoch en cours...",
+    "endEpochSuccess": "Epoch terminé avec succès",
+    "endEpochError": "Échec de la fin de l'epoch"
   },
   "Home": {
     "currentEpoch": "Epoch en cours",

--- a/programs/package.json
+++ b/programs/package.json
@@ -3,8 +3,9 @@
   "scripts": {
     "lint:fix": "prettier */*.js \"*/**/*{.js,.ts}\" -w",
     "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check",
-    "build": "anchor build && node scripts/copy-idl.js",
-    "copy-idl": "node scripts/copy-idl.js"
+    "build": "anchor build && node scripts/copy-idl.js && node scripts/copy-types.js",
+    "copy-idl": "node scripts/copy-idl.js",
+    "copy-types": "node scripts/copy-types.js"
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.30.1"

--- a/programs/scripts/copy-types.js
+++ b/programs/scripts/copy-types.js
@@ -1,0 +1,16 @@
+// copy-types.js
+
+import fs from "fs";
+import path from "path";
+
+const sourcePath = path.resolve("../programs/target/types/programs.ts");
+
+const destPath = path.resolve("../front/context/types/programs.ts");
+
+fs.copyFile(sourcePath, destPath, (err) => {
+  if (err) {
+    console.error("❌ Erreur lors de la copie du typage de programs.ts:", err);
+  } else {
+    console.log("✅ Typage programs.ts copié dans le dossier frontend !");
+  }
+});


### PR DESCRIPTION
# 📌 Description

- **Contexte** : Cette PR introduit l’affichage de la liste des époques dans l’application, ainsi qu’un bouton **"Close"** permettant aux administrateurs de fermer manuellement une époque depuis l’interface admin. Ces deux fonctionnalités s’intègrent à la page `/epoch` et s’appuient sur le `ProgramContext` pour interagir avec le programme Solana.
- **Problèmes résolus** :
  - Absence d’interface utilisateur pour visualiser les époques existantes.
  - Impossible pour les administrateurs de fermer une époque autrement qu’en passant par le backend ou en interagissant directement avec la blockchain.
- **Solutions apportées** :
  - **Création du composant `EpochList`** : Permet l’affichage des époques avec les informations principales (ID, dates, statut).
  - **Ajout d’un bouton "Close"** à côté de chaque époque ouverte, visible uniquement pour les administrateurs.
  - **Appel de la méthode `endEpoch`** via le `ProgramContext` pour fermer une époque.
  - **Affichage d’une boîte de confirmation** avant de lancer la transaction pour éviter les erreurs.
  - **Gestion des retours utilisateur** : Toast de confirmation ou message d’erreur selon le résultat de la transaction.
  - **Protection** : Le bouton est désactivé si l’époque est déjà fermée.
  - **UI responsive et cohérente** avec le reste de l’application (TailwindCSS, composants réutilisables).

## ✅ Type de changement

Cochez les options pertinentes :

- [ ] 🐛 Correction de bug  
- [x] ✨ Nouvelle fonctionnalité  
- [ ] 🔧 Refactoring  
- [ ] 📝 Mise à jour de la documentation  
- [ ] 🚀 Amélioration des performances  
- [ ] ✅ Ajout de tests  
- [ ] 🔒 Amélioration de la sécurité  
- [ ] Autre (précisez) :

## 🔍 Comment tester cette PR ?

1. Accédez à la page `/epoch`.
2. Vérifiez que la liste des époques s’affiche correctement.
3. Pour une époque active, cliquez sur le bouton **"Close"** à droite de la ligne correspondante.
4. Une boîte de confirmation s’affiche.
5. Confirmez pour déclencher la fermeture de l’époque via Solana.
6. Un toast de succès ou d’erreur s’affiche selon le résultat.
7. L’époque fermée est mise à jour automatiquement dans la liste (statut).

Résultats attendus :
- Les époques sont affichées avec leurs données correctes.
- Les boutons "Close" ne sont visibles que pour les époques actives.
- Une époque fermée n’est plus modifiable.
- Le `ProgramContext` gère proprement l’appel à `endEpoch`.

## 📎 Liens associés

- **Issues liées** :
  - #39 — [Feature] Lister les epochs  
  - #45 — [Feature] Bouton Close pour Epoch  
- **Documentation** : [Anchor - Docs](https://project-serum.github.io/anchor/)  
- **Autres PRs** : N/A

## 👥 Revue

- **Domaines concernés** : Interface admin, intégration frontend/blockchain, gestion des époques

## 🧪 Checklist

- [x] Le code compile sans erreur  
- [x] La liste des époques est fonctionnelle  
- [x] Le bouton "Close" appelle bien `endEpoch`  
- [x] La transaction se confirme sur Solana  
- [ ] La documentation sera mise à jour dans une PR séparée  
- [x] La PR est prête pour la revue  

## 📸 Captures d'écran (si applicable)


## 🗒️ Notes complémentaires

- Le `ProgramContext` est utilisé pour encapsuler l’appel à `endEpoch`, comme pour `startEpoch`.
- Des vérifications de rôle/admin sont en place côté frontend pour restreindre l’accès à l’action de fermeture.
- Le bouton "Close" est désactivé si l’époque est déjà fermée.
- Des logs de debug sont temporairement conservés pour faciliter les tests.
- Une version future pourra automatiser la fermeture selon l’heure de fin.
- Restreindre à l'avenir à 1 epoch active à la fois
- Toujours l'erreur "Type instantiation is excessively deep and possibly infinite."
- Ajout d'un script pour copier les types du program solana dans le répertoire front