### PR TITLE
73 feature creation update proposal status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,79 @@
 # NoRug.fun
 
-## Context & Vision
+[![Participating in the Colosseum Breakout Hackathon](https://img.shields.io/badge/Colosseum-Breakout%20Hackathon-blue?logo=solana)](https://www.colosseum.org/breakout)
 
-- **Context**: The DeFi sector is rapidly evolving, but issues with transparency, security, and innovation still persist. Investors are looking for reliable, transparent solutions with innovative ways to earn.
+## Context & Motivation
 
-- **Vision**: Build a platform on Solana with two phases:
-  1. **Phase 1**: Test and community engagement through a token proposal interface ("be the dev").
-  2. **Phase 2**: Launch the most successful projects through a pool, similar to Meteora.
+The Solana ecosystem has seen significant buzz, notably with the rise of platforms like [Pump.fun](https://pump.fun/) that have drawn capital and attention to meme coins. However, this rapid growth comes with challenges.
 
-## Features
+Established platforms like Raydium, with its "Launchlab," have attempted to structure token launches, but concerns remain regarding distribution transparency, the excessive creation of tokens, and dynamics that can sometimes extract value from the ecosystem rather than strengthen it.
 
-- **Vault and Epoch Management**: A vault stores SOL invested in Phase 1. A smart contract manages the opening and closing of epochs and the distribution of funds based on proposal success.
-- **Launch Pool (Phase 2)**: The top-performing projects from Phase 1 are launched via a pool, where tokens are allocated and distributed to initial investors.
+**NoRug.fun** aims to offer a fairer, more transparent, and community-driven alternative for launching new tokens on Solana.
 
-- **Modularity**: The architecture is modular, allowing additional features to be added without impacting the core system.
+## Vision & How It Works
 
-- **Front-End APIs and Integrations**: Secure APIs connect the front-end to the smart contracts.
+Our vision is to create a platform where token ideas can be proposed and backed by the community before their official launch, ensuring a fair and secure mechanism.
 
-- **Monitoring and Reporting**: Real-time tools track transactions, fundraising progress, and pool performance.
+The process unfolds in two main phases:
 
-- **User Experience**: Intuitive interface with crypto wallet integrations (Phantom, Solflare) and interactive dashboards for tracking epochs, vaults, and pools.
+### Phase 1: The Founder Window
 
-- **Specific Features**:
-  - Dedicated pages for token proposals ("be the dev"/"founder window").
-  - Investment tracking, real-time alerts, and notifications.
+1.  **Proposal (Founder):**
+    *   A creator proposes a token idea.
+    *   They define the name, symbol, and total supply.
+    *   They set the percentage of the supply they will receive (max 10%) and a lock-up period for their own tokens.
+2.  **Support (Co-Founder):**
+    *   Users (co-founders) browse active proposals.
+    *   They can support a proposal by investing SOL into it.
+3.  **Selection:**
+    *   At the end of a defined period (epoch), proposals are ranked based on the SOL raised.
+    *   The **top 10 proposals** are selected to move to the next phase.
+
+### Phase 2: Launch & Market
+
+1.  **Creation & Distribution:**
+    *   For the 10 winning proposals, NoRug.fun automatically handles:
+        *   The token **mint**.
+        *   The **distribution** of tokens to the creator (according to their defined %) and to the co-founders (proportionally to their SOL investment).
+    *   The initial liquidity pool is created on a DEX (via Meteora) using the SOL raised during Phase 1.
+2.  **Reclaim:**
+    *   Users who invested in **non-selected** proposals (outside the Top 10) can **reclaim their full SOL investment**.
+3.  **Open Market:**
+    *   The newly launched tokens are now tradable on the secondary market like any other Solana token.
+
+## Key Features (Implemented or Planned)
+
+*   **Epoch Management:** Smart contract to manage proposal cycles (opening, closing).
+*   **Proposal & Support Accounts:** Secure on-chain structures to store proposal details and user investments.
+*   **Secure Vault:** Temporary storage of invested SOL via program-controlled PDAs.
+*   **Ranking & Finalization Logic:** Off-chain service (crank) to determine winners and update on-chain statuses via a secure authority.
+*   **Liquidity Management:** Planned integration with Meteora for pool creation.
+*   **Intuitive User Interface:** Front-end (Next.js) to propose, browse, support, and (soon) reclaim funds/tokens.
+*   **Wallet Integration:** Support for major Solana wallets (Phantom, Solflare via Wallet Adapter).
 
 ## Technologies 💻
 
-- **Solana**: Blockchain platform for decentralized applications.
-- **Anchor**: Framework for developing secure and modular Solana programs.
-- **Next.js**: React framework for building server-side rendered applications.
-- **ShadCN**: Design system for scalable UI components.
-- **React**: JavaScript library for building user interfaces.
-- **TypeScript**: Statically typed superset of JavaScript for enhanced maintainability.
-- **Next Intl**: Internationalization library for Next.js applications.
+*   **Solana**: High-performance blockchain.
+*   **Anchor**: Development framework for Solana programs (Rust).
+*   **Rust**: Language for on-chain development.
+*   **Next.js**: React framework for the front-end (App Router).
+*   **TypeScript**: Typed superset of JavaScript.
+*   **Tailwind CSS / Shadcn UI**: For styling and UI components.
+*   **Next Intl**: Internationalization.
+*   **(Backend Service - upcoming)**: Likely Node.js/TypeScript for the 'crank' service.
+
+## Installation & Local Setup
+
+*(Keep or adapt existing instructions here if present and correct)*
+
+1.  Clone the repository.
+2.  Install root dependencies (`npm install` or `yarn`).
+3.  Navigate to `programs/programs` and build the Anchor program (`anchor build`).
+4.  Deploy to a local validator (`anchor deploy`).
+5.  (If necessary) Run the initialization script (e.g., for `initialize_program_config`).
+6.  Navigate to `front` and install dependencies (`npm install` or `yarn`).
+7.  Run the front-end development server (`npm run dev` or `yarn dev`).
 
 ## Credits 👨‍💻
 
-**[Alexandre Bourdois](https://github.com/alexandre-bourdois)**, **[Alexandre Kermarec](https://github.com/alexlakarm)**, **[Pierre-Yves Lejeune](https://github.com/pylejeune)**: Creators of the project.
+**[Alexandre Bourdois](https://github.com/alexandre-bourdois)**, **[Alexandre Kermarec](https://github.com/alexlakarm)**, **[Pierre-Yves Lejeune](https://github.com/pylejeune)**: Project creators as part of the [Colosseum Breakout Hackathon](https://www.colosseum.org/breakout).

--- a/programs/programs/programs/src/error.rs
+++ b/programs/programs/programs/src/error.rs
@@ -34,5 +34,18 @@ pub enum ErrorCode {
 
     #[msg("Dépassement de capacité lors du calcul")]
     Overflow,
+
+    // --- Nouveaux codes pour update_proposal_status --- 
+    #[msg("L'époque doit être fermée pour mettre à jour le statut de la proposition")]
+    EpochNotClosed,
+
+    #[msg("La proposition n'appartient pas à l'époque fournie")]
+    ProposalNotInEpoch,
+
+    #[msg("Le signataire n'est pas l'autorité autorisée")]
+    InvalidAuthority,
+
+    #[msg("Mise à jour du statut de la proposition invalide")]
+    InvalidProposalStatusUpdate,
 }
 

--- a/programs/programs/programs/src/error.rs
+++ b/programs/programs/programs/src/error.rs
@@ -47,5 +47,8 @@ pub enum ErrorCode {
 
     #[msg("Mise à jour du statut de la proposition invalide")]
     InvalidProposalStatusUpdate,
+
+    #[msg("La proposition a déjà un statut final (Validée ou Rejetée)")]
+    ProposalAlreadyFinalized,
 }
 

--- a/programs/programs/programs/src/instructions/initialize_program_config.rs
+++ b/programs/programs/programs/src/instructions/initialize_program_config.rs
@@ -1,0 +1,56 @@
+// Instruction pour initialiser la configuration globale du programme.
+//
+// Contexte de l'Autorité :
+// Ce programme utilise un compte singleton `ProgramConfig` (créé via un PDA avec la seed "config")
+// pour stocker une unique clé publique `admin_authority`.
+// Cette clé est la SEULE autorité reconnue par le programme Solana pour exécuter
+// des actions administratives sensibles (ex: `update_proposal_status`).
+//
+// Le programme Solana NE GÈRE PAS l'authentification ou l'autorisation de multiples
+// administrateurs humains. C'est la responsabilité d'un service backend off-chain.
+//
+// Le service backend doit :
+// 1. Détenir de manière SÉCURISÉE la clé privée correspondant à l'`admin_authority` définie ici.
+// 2. Gérer l'authentification et les permissions de plusieurs administrateurs humains (off-chain).
+// 3. Agir comme un proxy : lorsqu'un admin humain autorisé (via le backend) demande une action,
+//    le backend utilise la clé privée `admin_authority` pour signer et envoyer la transaction
+//    correspondante au programme Solana.
+//
+// Cette instruction `initialize_program_config` est conçue pour n'être appelée qu'UNE SEULE FOIS,
+// typiquement par le déployeur du programme, pour définir l'`admin_authority` initiale.
+// La structure `#[account(init, seeds = [b"config"], bump)]` empêche la réinitialisation.
+
+use anchor_lang::prelude::*;
+use crate::state::ProgramConfig;
+
+#[derive(Accounts)]
+pub struct InitializeProgramConfig<'info> {
+    // Le compte ProgramConfig à initialiser.
+    // Utilisation d'une seed fixe "config" pour en faire un singleton (ne peut être créé qu'une fois).
+    #[account(
+        init, 
+        payer = authority, 
+        space = 8 + ProgramConfig::INIT_SPACE, // 8 bytes pour le discriminateur Anchor
+        seeds = [b"config"], 
+        bump
+    )]
+    pub program_config: Account<'info, ProgramConfig>,
+
+    // L'autorité qui initialise la configuration (typiquement le déployeur ou un admin initial).
+    // Ce compte paiera aussi la rente pour le compte program_config.
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    // Requis pour l'initialisation du compte.
+    pub system_program: Program<'info, System>,
+}
+
+pub fn handler(ctx: Context<InitializeProgramConfig>, admin_authority: Pubkey) -> Result<()> {
+    msg!("Initializing ProgramConfig...");
+    
+    let config = &mut ctx.accounts.program_config;
+    config.admin_authority = admin_authority;
+
+    msg!("ProgramConfig initialized with admin authority: {}", admin_authority);
+    Ok(())
+} 

--- a/programs/programs/programs/src/instructions/mod.rs
+++ b/programs/programs/programs/src/instructions/mod.rs
@@ -3,8 +3,10 @@ pub mod get_epoch_state;
 pub mod end_epoch;
 pub mod get_proposal_details;
 pub mod initialize;
+pub mod initialize_program_config;
 pub mod start_epoch;
 pub mod support_proposal;
+pub mod update_proposal_status;
 
 pub use create_token_proposal::*;
 pub use start_epoch::*;
@@ -12,4 +14,6 @@ pub use get_epoch_state::*;
 pub use end_epoch::*;
 pub use get_proposal_details::*;
 pub use initialize::*;
+pub use initialize_program_config::*;
 pub use support_proposal::*;
+pub use update_proposal_status::*;

--- a/programs/programs/programs/src/instructions/update_proposal_status.rs
+++ b/programs/programs/programs/src/instructions/update_proposal_status.rs
@@ -31,15 +31,16 @@ pub struct UpdateProposalStatus<'info> {
 }
 
 pub fn handler(ctx: Context<UpdateProposalStatus>, new_status: ProposalStatus) -> Result<()> {
-    // La vérification de l'autorité est maintenant gérée par la contrainte ci-dessus.
+    // Vérifier que la proposition est actuellement active avant de la finaliser
+    require!(ctx.accounts.proposal.status == ProposalStatus::Active, ErrorCode::ProposalAlreadyFinalized);
 
+    // La vérification de l'autorité est gérée par la contrainte.
     // La vérification que new_status est Validated ou Rejected pourrait être ajoutée ici si nécessaire,
     // mais on suppose que le service off-chain envoie une valeur correcte.
-    // require!(new_status == ProposalStatus::Validated || new_status == ProposalStatus::Rejected, ErrorCode::InvalidProposalStatusUpdate);
 
     msg!("Updating proposal {} status from {:?} to {:?}", 
          ctx.accounts.proposal.key(), 
-         ctx.accounts.proposal.status, // Log l'ancien statut aussi
+         ctx.accounts.proposal.status, // Log l'ancien statut (devrait être Active)
          new_status);
     ctx.accounts.proposal.status = new_status;
 

--- a/programs/programs/programs/src/instructions/update_proposal_status.rs
+++ b/programs/programs/programs/src/instructions/update_proposal_status.rs
@@ -1,0 +1,47 @@
+use anchor_lang::prelude::*;
+use crate::state::{EpochManagement, EpochStatus, TokenProposal, ProposalStatus, ProgramConfig};
+// Placeholder pour un compte de configuration global - à définir dans state/mod.rs
+// use crate::state::ProgramConfig;
+use crate::error::ErrorCode;
+
+#[derive(Accounts)]
+pub struct UpdateProposalStatus<'info> {
+    // L'autorité doit signer et correspondre à l'autorité configurée dans ProgramConfig
+    #[account(constraint = authority.key() == program_config.admin_authority @ ErrorCode::InvalidAuthority)]
+    pub authority: Signer<'info>,
+    // Le compte contenant la configuration globale (et l'autorité admin)
+    pub program_config: Account<'info, ProgramConfig>,
+
+    // L'époque doit être fermée
+    #[account(
+        constraint = epoch_management.status == EpochStatus::Closed @ ErrorCode::EpochNotClosed
+    )]
+    pub epoch_management: Account<'info, EpochManagement>,
+
+    // La proposition doit appartenir à cette époque fermée
+    #[account(
+        mut, // Nécessite d'être mutable pour changer le statut
+        constraint = proposal.epoch_id == epoch_management.epoch_id @ ErrorCode::ProposalNotInEpoch
+    )]
+    pub proposal: Account<'info, TokenProposal>,
+
+    // On a besoin de system_program pour la création potentielle de comptes PDA,
+    // même s'il n'est pas directement utilisé ici, il est souvent nécessaire
+    // pub system_program: Program<'info, System>,
+}
+
+pub fn handler(ctx: Context<UpdateProposalStatus>, new_status: ProposalStatus) -> Result<()> {
+    // La vérification de l'autorité est maintenant gérée par la contrainte ci-dessus.
+
+    // La vérification que new_status est Validated ou Rejected pourrait être ajoutée ici si nécessaire,
+    // mais on suppose que le service off-chain envoie une valeur correcte.
+    // require!(new_status == ProposalStatus::Validated || new_status == ProposalStatus::Rejected, ErrorCode::InvalidProposalStatusUpdate);
+
+    msg!("Updating proposal {} status from {:?} to {:?}", 
+         ctx.accounts.proposal.key(), 
+         ctx.accounts.proposal.status, // Log l'ancien statut aussi
+         new_status);
+    ctx.accounts.proposal.status = new_status;
+
+    Ok(())
+} 

--- a/programs/programs/programs/src/lib.rs
+++ b/programs/programs/programs/src/lib.rs
@@ -16,6 +16,14 @@ declare_id!("89S48feUon6ffgtLzsnqoBVwdb1mxT4rmhRR5WnYefpA");
 pub mod programs {
     use super::*;
 
+    // --- Instruction d'initialisation de la config globale --- 
+    pub fn initialize_program_config(
+        ctx: Context<InitializeProgramConfig>,
+        admin_authority: Pubkey,
+    ) -> Result<()> {
+        initialize_program_config::handler(ctx, admin_authority)
+    }
+
     pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {
         initialize::handler(_ctx)
     }
@@ -64,5 +72,12 @@ pub mod programs {
         proposal_id: u64,
     ) -> Result<()> {
         get_proposal_details::handler(ctx, proposal_id)
+    }
+
+    pub fn update_proposal_status(
+        ctx: Context<UpdateProposalStatus>,
+        new_status: ProposalStatus,
+    ) -> Result<()> {
+        update_proposal_status::handler(ctx, new_status)
     }
 }

--- a/programs/programs/programs/src/state/mod.rs
+++ b/programs/programs/programs/src/state/mod.rs
@@ -34,7 +34,7 @@ pub struct TokenProposal {
     pub status: ProposalStatus,       // Enum indicating the proposal status
 }
 
-#[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq, Eq, InitSpace)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq, Eq, InitSpace, Debug)] // Added Debug to allow logging the status using msg! with {:?}
 pub enum ProposalStatus {
     Active,
     Validated,
@@ -55,4 +55,13 @@ pub struct UserProposalSupport {
 pub struct Treasury {
     pub authority: Pubkey,     // Public key authorized to manage the treasury
     pub platform_fees: u64,    // Total platform fees collected in lamports
+}
+
+// --- Nouveau compte de configuration globale ---
+#[account]
+#[derive(InitSpace)]
+pub struct ProgramConfig {
+    // Clé publique de l'autorité autorisée à exécuter certaines instructions (ex: update_proposal_status)
+    pub admin_authority: Pubkey,
+    // On pourrait ajouter d'autres paramètres globaux ici si nécessaire
 }

--- a/programs/tests/updateproposal.test.ts
+++ b/programs/tests/updateproposal.test.ts
@@ -1,0 +1,407 @@
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
+import { Programs } from "../target/types/programs";
+import { PublicKey } from "@solana/web3.js";
+import { expect } from "chai";
+import { generateRandomId, setupTestEnvironment } from "./utils.test";
+
+describe("Tests de la mise à jour du statut des propositions", () => {
+  const { provider, program } = setupTestEnvironment();
+  let programConfigPda: PublicKey;
+  let adminAuthority: anchor.web3.Keypair; // L'autorité qui sera définie dans ProgramConfig
+  let epochPda: PublicKey;
+  let proposalPda: PublicKey;
+  const epochId = generateRandomId();
+  const tokenName = "testUpdateToken";
+  const tokenSymbol = "TUT";
+
+  // --- Helper Function --- 
+  async function setupClosedEpochWithProposal(epochId: anchor.BN, tokenName: string, tokenSymbol: string) {
+    console.log(`\n--- Setting up Epoch ${epochId} & Proposal ${tokenName} ---`);
+    const creator = provider.wallet;
+    const startTime = new anchor.BN(Math.floor(Date.now() / 1000) - 10); // Start 10s ago
+    const endTime = new anchor.BN(startTime.toNumber() + 5);      // End soon
+
+    // Derive PDAs
+    const [currentEpochPda] = PublicKey.findProgramAddressSync(
+      [Buffer.from("epoch"), epochId.toArrayLike(Buffer, "le", 8)],
+      program.programId
+    );
+    const [currentProposalPda] = PublicKey.findProgramAddressSync(
+      [
+        Buffer.from("proposal"),
+        creator.publicKey.toBuffer(),
+        epochId.toArrayLike(Buffer, "le", 8),
+        Buffer.from(tokenName),
+      ],
+      program.programId
+    );
+
+    // Create Epoch (handle exists)
+    try {
+      await program.methods
+        .startEpoch(epochId, startTime, endTime)
+        .accounts({ authority: creator.publicKey, epochManagement: currentEpochPda, systemProgram: anchor.web3.SystemProgram.programId })
+        .rpc();
+      console.log(`Epoch ${epochId} created.`);
+    } catch(err) { console.log(`Epoch ${epochId} likely already exists.`); }
+
+    // Create Proposal (handle exists)
+    try {
+      await program.methods
+        .createProposal(tokenName, tokenSymbol, new anchor.BN(1000), 5, new anchor.BN(0))
+        .accounts({ creator: creator.publicKey, tokenProposal: currentProposalPda, epoch: currentEpochPda, systemProgram: anchor.web3.SystemProgram.programId })
+        .rpc();
+      console.log(`Proposal ${tokenName} created.`);
+    } catch(err) { console.log(`Proposal ${tokenName} likely already exists.`); }
+
+    // Wait for epoch end
+    const waitTime = Math.max(0, endTime.toNumber() * 1000 - Date.now() + 1000); // Wait 1s past end time
+    console.log(`Waiting ${waitTime / 1000}s for epoch to end...`);
+    await new Promise(resolve => setTimeout(resolve, waitTime));
+
+    // Close Epoch (handle already closed)
+    try {
+      const epochState = await program.account.epochManagement.fetch(currentEpochPda);
+      if (JSON.stringify(epochState.status) !== JSON.stringify({ closed: {} })) {
+        await program.methods.endEpoch(epochId)
+          .accounts({ epochManagement: currentEpochPda, authority: creator.publicKey, systemProgram: anchor.web3.SystemProgram.programId })
+          .rpc();
+        console.log(`Epoch ${epochId} closed.`);
+      } else { console.log(`Epoch ${epochId} was already closed.`); }
+    } catch(err) { console.log(`Failed to close epoch ${epochId} (may be already closed): ${err.message}`); }
+
+    // Verify epoch is closed
+    const closedEpoch = await program.account.epochManagement.fetch(currentEpochPda);
+    expect(closedEpoch.status).to.deep.equal({ closed: {} });
+
+    // Verify proposal is active
+    const proposal = await program.account.tokenProposal.fetch(currentProposalPda);
+    // Reset status to Active if needed for re-running tests cleanly
+    if (JSON.stringify(proposal.status) !== JSON.stringify({ active: {} })) {
+        console.warn(`Proposal ${tokenName} was not Active. Attempting reset via direct account write (TEST ONLY!).`);
+        // THIS IS FOR TESTING ONLY - requires direct modification which isn't standard practice
+        // In a real scenario, you wouldn't reset status like this.
+        // A better test approach might involve creating unique proposals per test.
+        // For now, we accept this limitation for simpler test code.
+        // proposal.status = { active: {} }; // This line won't actually work as fetch returns a copy
+        // Need to call an instruction (if one existed) or accept tests might fail on re-run without reset
+         console.warn("Cannot reset proposal status easily in test. Subsequent tests might fail if run out of order or re-run without validator reset.");
+         // We will proceed assuming the proposal *should* be active after creation.
+         expect(proposal.status).to.deep.equal({ active: {} }, "Proposal status should be Active after creation");
+    }
+
+    console.log(`--- Setup complete for Epoch ${epochId} & Proposal ${tokenName} ---`);
+    return { currentEpochPda, currentProposalPda };
+  }
+  // --- End Helper Function ---
+
+  before(async () => {
+    // Générer une nouvelle clé pour l'autorité admin pour ce test
+    adminAuthority = anchor.web3.Keypair.generate();
+    // Financer cette nouvelle autorité pour qu'elle puisse payer les frais
+    const lamports = 1 * anchor.web3.LAMPORTS_PER_SOL;
+    const signature = await provider.connection.requestAirdrop(adminAuthority.publicKey, lamports);
+    await provider.connection.confirmTransaction(signature, "confirmed");
+    console.log(`Admin authority ${adminAuthority.publicKey} funded.`);
+
+    // Trouver l'adresse du PDA pour ProgramConfig
+    [programConfigPda] = PublicKey.findProgramAddressSync(
+      [Buffer.from("config")],
+      program.programId
+    );
+    console.log(`ProgramConfig PDA: ${programConfigPda}`);
+  });
+
+  it("Initialise la configuration du programme (ProgramConfig)", async () => {
+    console.log("\nTest: Initialisation ProgramConfig");
+    console.log("---------------------------------------");
+    try {
+      const tx = await program.methods
+        .initializeProgramConfig(adminAuthority.publicKey) // Passer la clé publique de l'admin souhaité
+        .accounts({
+          programConfig: programConfigPda,
+          authority: provider.wallet.publicKey, // L'autorité qui paie et initialise (le wallet du provider ici)
+          systemProgram: anchor.web3.SystemProgram.programId,
+        })
+        .rpc();
+      console.log("Transaction signature:", tx);
+
+      // Vérifier que le compte a été créé et contient la bonne autorité
+      const configAccount = await program.account.programConfig.fetch(programConfigPda);
+      console.log("Admin authority set in ProgramConfig:", configAccount.adminAuthority.toString());
+      expect(configAccount.adminAuthority.toString()).to.equal(adminAuthority.publicKey.toString());
+
+    } catch (error) {
+      console.error("Erreur lors de l'initialisation de ProgramConfig:", error);
+      // Essayer d'appeler une deuxième fois pour voir si l'erreur attendue se produit
+      try {
+        await program.methods
+          .initializeProgramConfig(adminAuthority.publicKey)
+          .accounts({
+            programConfig: programConfigPda,
+            authority: provider.wallet.publicKey,
+            systemProgram: anchor.web3.SystemProgram.programId,
+          })
+          .rpc();
+          expect.fail("L'initialisation aurait dû échouer la deuxième fois");
+      } catch (innerError) {
+        console.log("Erreur attendue lors de la deuxième initialisation:", innerError.message);
+        expect(innerError.message).to.include("Allocate: account Address { address: " + programConfigPda.toString()); // Anchor lève une erreur d'allocation
+      }
+      // Ne pas faire échouer le test si la première tentative a échoué car le compte existait déjà (runs précédents)
+      console.log("L'initialisation a peut-être échoué car le compte existait déjà (normal si tests relancés).");
+      // Re-vérifier que l'autorité est correcte dans ce cas
+      const configAccount = await program.account.programConfig.fetch(programConfigPda);
+      expect(configAccount.adminAuthority.toString()).to.equal(adminAuthority.publicKey.toString());
+    }
+  });
+
+  it("Met à jour le statut d'une proposition vers Validated", async () => {
+    console.log("\nTest: Update Proposal Status to Validated");
+    console.log("---------------------------------------------");
+    const { currentEpochPda, currentProposalPda } = await setupClosedEpochWithProposal(epochId, tokenName, tokenSymbol);
+
+    // --- Appel de l'instruction à tester --- 
+    try {
+      const tx = await program.methods
+        .updateProposalStatus({ validated: {} })
+        .accounts({
+          authority: adminAuthority.publicKey,
+          programConfig: programConfigPda,
+          epochManagement: currentEpochPda,
+          proposal: currentProposalPda,
+        })
+        .signers([adminAuthority])
+        .rpc();
+      console.log("Transaction updateProposalStatus (Validated) signature:", tx);
+
+      // --- Vérification --- 
+      const proposalAfter = await program.account.tokenProposal.fetch(currentProposalPda);
+      console.log(`Statut de la proposition APRÈS: ${JSON.stringify(proposalAfter.status)}`);
+      expect(proposalAfter.status).to.deep.equal({ validated: {} });
+
+    } catch (error) {
+      console.error("Erreur lors de l'appel à updateProposalStatus (Validated):", error);
+      throw error;
+    }
+  });
+
+  it("Met à jour le statut d'une proposition vers Rejected", async () => {
+    console.log("\nTest: Update Proposal Status to Rejected");
+    console.log("---------------------------------------------");
+    const epochId = generateRandomId(); // Utiliser un nouvel ID pour être sûr
+    const tokenName = "rejectMe";
+    const tokenSymbol = "REJ";
+    const { currentEpochPda, currentProposalPda } = await setupClosedEpochWithProposal(epochId, tokenName, tokenSymbol);
+
+    // --- Appel de l'instruction à tester --- 
+    try {
+      const tx = await program.methods
+        .updateProposalStatus({ rejected: {} }) // Le nouveau statut
+        .accounts({
+          authority: adminAuthority.publicKey,
+          programConfig: programConfigPda,
+          epochManagement: currentEpochPda,
+          proposal: currentProposalPda,
+        })
+        .signers([adminAuthority])
+        .rpc();
+      console.log("Transaction updateProposalStatus (Rejected) signature:", tx);
+
+      // --- Vérification --- 
+      const proposalAfter = await program.account.tokenProposal.fetch(currentProposalPda);
+      console.log(`Statut de la proposition APRÈS: ${JSON.stringify(proposalAfter.status)}`);
+      expect(proposalAfter.status).to.deep.equal({ rejected: {} }); // Vérifie le nouveau statut
+
+    } catch (error) {
+      console.error("Erreur lors de l'appel à updateProposalStatus (Rejected):", error);
+      throw error;
+    }
+  });
+
+  it("Échoue si l'autorité signataire n'est pas la bonne", async () => {
+    console.log("\nTest: Failure with Unauthorized Signer");
+    console.log("---------------------------------------------");
+    const epochId = generateRandomId();
+    const tokenName = "unauthAttempt";
+    const tokenSymbol = "UNA";
+    const { currentEpochPda, currentProposalPda } = await setupClosedEpochWithProposal(epochId, tokenName, tokenSymbol);
+
+    // Générer une autorité non autorisée
+    const unauthorizedAuthority = anchor.web3.Keypair.generate();
+    // La financer (nécessaire pour signer/payer la transaction)
+    const lamports = 0.1 * anchor.web3.LAMPORTS_PER_SOL;
+    const signature = await provider.connection.requestAirdrop(unauthorizedAuthority.publicKey, lamports);
+    await provider.connection.confirmTransaction(signature, "confirmed");
+    console.log(`Unauthorized authority ${unauthorizedAuthority.publicKey} funded.`);
+
+    try {
+      await program.methods
+        .updateProposalStatus({ validated: {} })
+        .accounts({
+          authority: unauthorizedAuthority.publicKey, // Utiliser la mauvaise clé publique
+          programConfig: programConfigPda,
+          epochManagement: currentEpochPda,
+          proposal: currentProposalPda,
+        })
+        .signers([unauthorizedAuthority]) // Signer avec la mauvaise clé privée
+        .rpc();
+      
+      // Si l'appel réussit, le test échoue
+      expect.fail("L'appel aurait dû échouer car l'autorité n'est pas valide");
+    } catch (error) {
+      // Vérifier que l'erreur est bien celle attendue
+      console.log("Erreur attendue interceptée:", error.message);
+      expect(error.message).to.include("InvalidAuthority"); // Nouvelle vérification
+      console.log("Vérifié que l'erreur contient 'InvalidAuthority'");
+
+      // Vérifier que le statut de la proposition n'a pas changé
+      const proposalAfter = await program.account.tokenProposal.fetch(currentProposalPda);
+      expect(proposalAfter.status).to.deep.equal({ active: {} }, "Proposal status should not have changed");
+    }
+  });
+
+  it("Échoue si l'époque n'est pas fermée (Closed)", async () => {
+    console.log("\nTest: Failure when Epoch is not Closed");
+    console.log("---------------------------------------------");
+    const epochId = generateRandomId();
+    const tokenName = "epochActiveTest";
+    const tokenSymbol = "EAT";
+    const creator = provider.wallet;
+
+    // 1. Créer une époque qui reste active (endTime loin dans le futur)
+    const startTime = new anchor.BN(Math.floor(Date.now() / 1000) - 10);
+    const endTime = new anchor.BN(startTime.toNumber() + 3600 * 24); // Fin dans 1 jour
+    const [activeEpochPda] = PublicKey.findProgramAddressSync(
+      [Buffer.from("epoch"), epochId.toArrayLike(Buffer, "le", 8)],
+      program.programId
+    );
+    try {
+        await program.methods
+          .startEpoch(epochId, startTime, endTime)
+          .accounts({ authority: creator.publicKey, epochManagement: activeEpochPda, systemProgram: anchor.web3.SystemProgram.programId })
+          .rpc();
+        console.log(`Époque active ${epochId} créée.`);
+    } catch(err) { console.log(`Époque active ${epochId} déjà existante (normal si tests relancés).`); }
+    
+    // Vérifier que l'époque est bien active
+    const epochState = await program.account.epochManagement.fetch(activeEpochPda);
+    expect(epochState.status).to.deep.equal({ active: {} });
+
+    // 2. Créer une proposition dans cette époque active
+    const [activeProposalPda] = PublicKey.findProgramAddressSync(
+      [
+        Buffer.from("proposal"),
+        creator.publicKey.toBuffer(),
+        epochId.toArrayLike(Buffer, "le", 8),
+        Buffer.from(tokenName),
+      ],
+      program.programId
+    );
+    try {
+        await program.methods
+          .createProposal(tokenName, tokenSymbol, new anchor.BN(1000), 5, new anchor.BN(0))
+          .accounts({ creator: creator.publicKey, tokenProposal: activeProposalPda, epoch: activeEpochPda, systemProgram: anchor.web3.SystemProgram.programId })
+          .rpc();
+        console.log(`Proposition ${tokenName} créée dans l'époque active.`);
+    } catch(err) { console.log(`Proposition ${tokenName} déjà existante (normal si tests relancés).`); }
+
+    // 3. Tenter de mettre à jour le statut alors que l'époque est active
+    try {
+      await program.methods
+        .updateProposalStatus({ validated: {} })
+        .accounts({
+          authority: adminAuthority.publicKey,
+          programConfig: programConfigPda,
+          epochManagement: activeEpochPda, // L'époque est active
+          proposal: activeProposalPda,
+        })
+        .signers([adminAuthority])
+        .rpc();
+
+      expect.fail("L'appel aurait dû échouer car l'époque n'est pas fermée");
+    } catch (error) {
+      console.log("Erreur attendue interceptée:", error.message);
+      expect(error.message).to.include("EpochNotClosed"); // Nouvelle vérification
+      console.log("Vérifié que l'erreur contient 'EpochNotClosed'");
+
+      // Vérifier que le statut de la proposition n'a pas changé
+      const proposalAfter = await program.account.tokenProposal.fetch(activeProposalPda);
+      expect(proposalAfter.status).to.deep.equal({ active: {} }, "Proposal status should remain Active");
+    }
+  });
+
+  // --- Tests for preventing status change after finalization ---
+
+  it("Échoue si on essaie de passer de Validated à Rejected", async () => {
+    console.log("\nTest: Failure Validated -> Rejected");
+    console.log("---------------------------------------------");
+    const epochId = generateRandomId();
+    const tokenName = "alreadyValidated";
+    const tokenSymbol = "ALV";
+    const { currentEpochPda, currentProposalPda } = await setupClosedEpochWithProposal(epochId, tokenName, tokenSymbol);
+
+    // 1. Passer à Validated (vérifié dans un test précédent, on le fait ici comme setup)
+    await program.methods
+        .updateProposalStatus({ validated: {} })
+        .accounts({ authority: adminAuthority.publicKey, programConfig: programConfigPda, epochManagement: currentEpochPda, proposal: currentProposalPda })
+        .signers([adminAuthority])
+        .rpc();
+    
+    const validatedProposal = await program.account.tokenProposal.fetch(currentProposalPda);
+    expect(validatedProposal.status).to.deep.equal({ validated: {} });
+
+    // 2. Tenter de passer à Rejected
+    try {
+        await program.methods
+          .updateProposalStatus({ rejected: {} }) // Tenter de changer
+          .accounts({ authority: adminAuthority.publicKey, programConfig: programConfigPda, epochManagement: currentEpochPda, proposal: currentProposalPda })
+          .signers([adminAuthority])
+          .rpc();
+        expect.fail("L'appel aurait dû échouer car la proposition est déjà Validated");
+    } catch (error) {
+        console.log("Erreur attendue interceptée:", error.message);
+        // Vérifier l'erreur spécifique ProposalAlreadyFinalized
+        expect(error.message).to.include("ProposalAlreadyFinalized"); 
+        // Ou vérifier le code d'erreur si possible
+        // expect(error.error.errorCode.code).to.equal("ProposalAlreadyFinalized");
+        // expect(error.error.errorCode.number).to.equal(6015); // A vérifier
+    }
+  });
+
+  it("Échoue si on essaie de passer de Rejected à Validated", async () => {
+    console.log("\nTest: Failure Rejected -> Validated");
+    console.log("---------------------------------------------");
+    const epochId = generateRandomId();
+    const tokenName = "alreadyRejected";
+    const tokenSymbol = "ALR";
+    const { currentEpochPda, currentProposalPda } = await setupClosedEpochWithProposal(epochId, tokenName, tokenSymbol);
+
+    // 1. Passer à Rejected (vérifié dans un test précédent, on le fait ici comme setup)
+    await program.methods
+        .updateProposalStatus({ rejected: {} })
+        .accounts({ authority: adminAuthority.publicKey, programConfig: programConfigPda, epochManagement: currentEpochPda, proposal: currentProposalPda })
+        .signers([adminAuthority])
+        .rpc();
+
+    const rejectedProposal = await program.account.tokenProposal.fetch(currentProposalPda);
+    expect(rejectedProposal.status).to.deep.equal({ rejected: {} });
+
+    // 2. Tenter de passer à Validated
+    try {
+        await program.methods
+          .updateProposalStatus({ validated: {} }) // Tenter de changer
+          .accounts({ authority: adminAuthority.publicKey, programConfig: programConfigPda, epochManagement: currentEpochPda, proposal: currentProposalPda })
+          .signers([adminAuthority])
+          .rpc();
+        expect.fail("L'appel aurait dû échouer car la proposition est déjà Rejected");
+    } catch (error) {
+        console.log("Erreur attendue interceptée:", error.message);
+        expect(error.message).to.include("ProposalAlreadyFinalized");
+        // expect(error.error.errorCode.code).to.equal("ProposalAlreadyFinalized");
+        // expect(error.error.errorCode.number).to.equal(6015);
+    }
+  });
+
+}); 


### PR DESCRIPTION
# ✨ Feat(program): Ajout instructions initialize_program_config et update_proposal_status

## 📌 Description

-   **Contexte** : Après la clôture d'une époque, il est nécessaire de déterminer et d'enregistrer on-chain le statut final (`Validated` ou `Rejected`) des propositions de tokens associées. Cette action doit être effectuée par une entité de confiance (le service backend) via une autorisation sécurisée.
-   **Problème résolu** : Le programme ne disposait pas d'instruction pour mettre à jour le statut des propositions après la fin d'une époque. Il manquait également un mécanisme pour définir et vérifier de manière sécurisée l'autorité autorisée à effectuer cette action sensible.
-   **Solution apportée** :
    1.  **Configuration Globale :**
        *   Ajout d'une structure de compte `ProgramConfig` (`state/mod.rs`) destinée à stocker les configurations globales. Pour l'instant, elle contient `admin_authority: Pubkey`.
        *   Ce compte est conçu comme un singleton via un PDA dérivé de la seed fixe `b"config"`.
    2.  **Initialisation de l'Autorité :**
        *   Création d'une instruction `initialize_program_config` (`instructions/initialize_program_config.rs`, ajoutée à `lib.rs`).
        *   Rôle : Initialiser le compte `ProgramConfig` et définir la clé publique `admin_authority`.
        *   **Usage unique :** Cette instruction est destinée à n'être appelée qu'**une seule fois** après le déploiement initial du programme (typiquement par la clé de déploiement). L'utilisation d'un PDA fixe avec `#[account(init)]` empêche techniquement les appels ultérieurs.
    3.  **Mise à Jour du Statut :**
        *   Création d'une instruction `update_proposal_status` (`instructions/update_proposal_status.rs`, ajoutée à `lib.rs`).
        *   Rôle : Permet de changer le statut d'un `TokenProposal` à `Validated` ou `Rejected`.
        *   **Contrôles de Sécurité et Logique :**
            *   **Vérification d'Autorité :** L'instruction vérifie que le signataire (`authority: Signer<'info>`) correspond à l'`admin_authority` stockée dans le compte `ProgramConfig`.
            *   **Rôle du Service Off-chain :** Il est crucial de noter que l'`admin_authority` on-chain est unique. C'est le **service backend (off-chain)** qui doit détenir la **clé privée** correspondante de manière sécurisée. Ce service gérera l'authentification/autorisation de plusieurs administrateurs humains (via son propre système) et agira comme proxy pour signer les transactions `update_proposal_status` avec la clé privée on-chain autorisée.
            *   **Statut Époque :** Vérifie que l'époque associée (`EpochManagement`) est bien `Closed`.
            *   **Appartenance Époque :** Vérifie que la `TokenProposal` appartient bien à l'`EpochManagement` fournie.
            *   **Statut Proposition :** Vérifie que le statut *actuel* de la `TokenProposal` est `Active`. Il est impossible de modifier une proposition déjà `Validated` ou `Rejected`.
    4.  **Gestion des Erreurs :** Ajout des codes d'erreur nécessaires (`EpochNotClosed`, `ProposalNotInEpoch`, `InvalidAuthority`, `ProposalAlreadyFinalized`) dans `error.rs`.
    5.  **Tests :** Création d'une nouvelle suite de tests `updateproposal.test.ts` couvrant :
        *   L'initialisation de `ProgramConfig`.
        *   La mise à jour réussie vers `Validated` et `Rejected`.
        *   Les cas d'échec (autorité invalide, époque non fermée, proposition déjà finalisée).
    6.  **Divers :** Ajout du `derive(Debug)` à `ProposalStatus` pour faciliter le logging dans les tests.

## ✅ Type de changement

Cochez les options pertinentes :

-   [ ] 🐛 Correction de bug
-   [x] ✨ Nouvelle fonctionnalité
-   [ ] 🔧 Refactoring
-   [ ] 📝 Mise à jour de la documentation (via commentaires de code)
-   [ ] 🚀 Amélioration des performances
-   [x] ✅ Ajout de tests
-   [x] 🔒 Amélioration de la sécurité
-   [ ] Autre (précisez) :

## 🔍 Comment tester cette PR ?

Fournissez des instructions pour tester les modifications :

1.  Naviguer vers le répertoire `programs/programs/`.
2.  Lancer la commande `anchor test`.
3.  Vérifier que tous les tests (y compris ceux dans `epoch.test.ts`, `proposal.test.ts`, et le nouveau `updateproposal.test.ts`) passent avec succès.

## 📎 Liens associés

-   **Issues liées** : #73 (Ajuster si nécessaire)
-   **Documentation** : N/A
-   **Autres PRs** : N/A

## 👥 Revue

-   **Relecteurs suggérés** : @NomUtilisateur (À compléter)
-   **Domaines concernés** : Programme Solana (Instructions, State, Tests, Erreurs)

## 🧪 Checklist

-   [x] Le code compile sans erreur (`anchor build`)
-   [x] Les tests unitaires passent (`anchor test`)
-   [x] La documentation est à jour (Commentaires de code ajoutés pour expliquer la logique)
-   [x] Les dépendances sont à jour (Aucune dépendance ajoutée/modifiée)
-   [x] La PR est prête pour la revue

## 📸 Captures d'écran (si applicable)

N/A (Fonctionnalité Backend)

## 🗒️ Notes complémentaires

-   Le déploiement de cette mise à jour nécessitera un appel unique à l'instruction `initialize_program_config` pour définir l'`admin_authority` sur le réseau cible (devnet, mainnet).
-   Le service backend devra être mis à jour pour :
    *   Stocker de manière sécurisée la clé privée correspondant à l'`admin_authority`.
    *   Implémenter la logique de détermination des statuts (`Validated`/`Rejected`) après la fermeture d'une époque.
    *   Appeler l'instruction `update_proposal_status` pour chaque proposition concernée, en utilisant la clé privée `admin_authority` pour signer.