### PR TITLE
79 chore correction calcul supporter allocation dans create token proposal

### DIFF
--- a/programs/programs/programs/src/instructions/create_token_proposal.rs
+++ b/programs/programs/programs/src/instructions/create_token_proposal.rs
@@ -75,7 +75,9 @@ pub fn handler(
     proposal.token_symbol = token_symbol;
     proposal.total_supply = total_supply;
     proposal.creator_allocation = creator_allocation;
-    proposal.supporter_allocation = 100 - creator_allocation; // Le reste va aux supporters
+    // Calculer la part restante et l'allocation des supporters (arrondi supérieur)
+    let remaining_allocation = 100u8.saturating_sub(creator_allocation);
+    proposal.supporter_allocation = remaining_allocation.saturating_add(1) / 2;
     proposal.sol_raised = 0;
     proposal.total_contributions = 0;
     proposal.lockup_period = lockup_period;

--- a/programs/programs/programs/src/state/mod.rs
+++ b/programs/programs/programs/src/state/mod.rs
@@ -28,7 +28,7 @@ pub struct TokenProposal {
     pub token_symbol: String,         // Token symbol
     pub total_supply: u64,            // Total token supply
     pub creator_allocation: u8,       // % of supply for the creator (max 10%)
-    pub supporter_allocation: u8,     // % of supply for supporters (calculated by norug)
+    pub supporter_allocation: u8,     // % for supporters = ceil((100 - creator_allocation) / 2)
     pub sol_raised: u64,              // SOL raised via UserProposalSupport
     pub total_contributions: u64,     // Number of supporters
     pub lockup_period: i64,           // Lock-up period in seconds during which the creator cannot sell

--- a/programs/tests/proposal.test.ts
+++ b/programs/tests/proposal.test.ts
@@ -71,6 +71,9 @@ describe("Tests des propositions de tokens", () => {
     const epoch = await program.account.epochManagement.fetch(epochPda);
     const epochId = epoch.epochId;
     
+    // Définir l'allocation créateur pour ce test
+    const creatorAllocation = 10; 
+
     [proposalPda] = PublicKey.findProgramAddressSync(
       [
         Buffer.from("proposal"),
@@ -107,12 +110,24 @@ describe("Tests des propositions de tokens", () => {
 
     // Vérifier que la proposition a été créée correctement
     const proposal = await program.account.tokenProposal.fetch(proposalPda);
-    console.log("Valeurs attendues pour la proposition:");
+
+    // --- Vérification du calcul de supporter_allocation --- 
+    const remainingAllocation = 100 - creatorAllocation;
+    const expectedSupporterAllocation = Math.ceil(remainingAllocation / 2); // Calcul attendu
+    console.log("\nVérification Allocation Supporter:");
+    console.log(`- Creator Allocation: ${creatorAllocation}%`);
+    console.log(`- Remaining Allocation: ${remainingAllocation}%`);
+    console.log(`- Expected Supporter Allocation (ceil(remaining/2)): ${expectedSupporterAllocation}%`);
+    console.log(`- Actual Supporter Allocation: ${proposal.supporterAllocation}%`);
+    expect(proposal.supporterAllocation).to.equal(expectedSupporterAllocation);
+    // ------------------------------------------------------
+
+    console.log("\nValeurs attendues pour la proposition:");
     console.log(`- tokenName: ${tokenName}`);
     console.log(`- tokenSymbol: ${tokenSymbol}`);
     console.log(`- totalSupply: ${totalSupply.toString()}`);
     console.log(`- creatorAllocation: ${creatorAllocation}`);
-    console.log(`- supporterAllocation: ${100 - creatorAllocation}`);
+    console.log(`- supporterAllocation: ${expectedSupporterAllocation}`);
     console.log(`- solRaised: 0`);
     console.log(`- totalContributions: 0`);
     console.log(`- lockupPeriod: ${lockupPeriod.toString()}`);
@@ -131,7 +146,7 @@ describe("Tests des propositions de tokens", () => {
     expect(proposal.tokenSymbol).to.equal(tokenSymbol);
     expect(proposal.totalSupply.toString()).to.equal(totalSupply.toString());
     expect(proposal.creatorAllocation).to.equal(creatorAllocation);
-    expect(proposal.supporterAllocation).to.equal(100 - creatorAllocation);
+    expect(proposal.supporterAllocation).to.equal(expectedSupporterAllocation);
     expect(proposal.solRaised.toString()).to.equal("0");
     expect(proposal.totalContributions.toString()).to.equal("0");
     expect(proposal.lockupPeriod.toString()).to.equal(lockupPeriod.toString());


### PR DESCRIPTION
# feat(proposal): Correct supporter_allocation calculation in create_proposal

## 📌 Description

-   **Contexte** : L'instruction `create_token_proposal` calculait l'allocation des tokens pour les supporters (`supporter_allocation`) comme étant simplement le reste de la supply après l'allocation du créateur (`100 - creator_allocation`).
-   **Problème résolu** : Ce calcul pouvait désavantager les supporters par rapport à la liquidité initiale du pool. L'allocation des supporters doit être au moins égale à la moitié de la supply restante pour garantir une répartition plus équitable.
-   **Solution apportée** : Le calcul de `supporter_allocation` a été modifié pour utiliser la formule `ceil((100 - creator_allocation) / 2)` (arrondi supérieur).
Cf wiki pour plus dé détails sur ce calcul, en deux mots l'idée est que la supply dédiée au supporters d'une proposal doit être au moins égale à celle allouée à la Pool pour qu'ils ne soient pas perdants au launch.
Le commentaire associé dans `state/mod.rs` a été mis à jour. Un test spécifique a été ajouté pour vérifier ce calcul.

## ✅ Type de changement

Cochez les options pertinentes :

-   [x] 🐛 Correction de bug (logique de calcul incorrecte)
-   [ ] ✨ Nouvelle fonctionnalité
-   [x] 🔧 Refactoring (amélioration du calcul)
-   [ ] 📝 Mise à jour de la documentation
-   [ ] 🚀 Amélioration des performances
-   [x] ✅ Ajout de tests
-   [ ] 🔒 Amélioration de la sécurité
-   [ ] Autre (précisez) :

## 🧪 Tests ajoutés

-   Le test `Crée une nouvelle proposition de token` dans `programs/tests/proposal.test.ts` a été modifié.
-   Il inclut désormais une vérification explicite que `proposal.supporterAllocation` est égal à `Math.ceil((100 - creatorAllocation) / 2)`.
-   Les logs du test affichent également les allocations attendues et réelles pour faciliter la vérification.

## 🔍 Comment tester cette PR ?

1.  S'assurer qu'un validator local tourne (`solana-test-validator --reset`).
2.  Se placer dans le répertoire `programs`.
3.  Lancer les tests : `anchor test` ou `anchor test tests/proposal.test.ts`.
4.  Vérifier que tous les tests passent.
5.  Examiner les logs du test `Crée une nouvelle proposition de token` et confirmer que la section "Vérification Allocation Supporter" affiche des valeurs cohérentes et que l'assertion passe.

## 📎 Liens associés

-   **Issues liées** : #79
-   **Instruction modifiée**: [`programs/programs/programs/src/instructions/create_token_proposal.rs`](programs/programs/programs/src/instructions/create_token_proposal.rs)
-   **État modifié**: [`programs/programs/programs/src/state/mod.rs`](programs/programs/programs/src/state/mod.rs)
-   **Test modifié**: [`programs/tests/proposal.test.ts`](programs/tests/proposal.test.ts)

## 👥 Revue

-   **Relecteurs suggérés** : @pylejeune @alexandre-bourdois 
-   **Domaines concernés** : Smart Contract (Logique `create_proposal`), State Management, Tests Anchor.

## ✅ Checklist

-   [x] Le code compile sans erreur (`anchor build`)
-   [x] Les tests unitaires passent (`anchor test`)
-   [ ] La documentation est à jour (N/A pour ce changement)
-   [ ] Les dépendances sont à jour (Non modifié)
-   [x] La PR est prête pour la revue

## 📸 Captures d'écran (si applicable)

<img width="578" alt="image" src="https://github.com/user-attachments/assets/ebd9810c-ca00-4489-abb7-e43f6d098a77" />

## 🗒️ Notes complémentaires

Le calcul utilise `u8.saturating_sub` et `u8.saturating_add(1) / 2` pour implémenter l'arrondi supérieur en arithmétique entière Rust.