### PR TITLE
feat(cluster): add option to choose localhost or devnet

### DIFF
--- a/front/components/wallet/AppWalletProvider.tsx
+++ b/front/components/wallet/AppWalletProvider.tsx
@@ -9,26 +9,28 @@ import React, { useMemo } from "react";
 // import { UnsafeBurnerWalletAdapter } from "@solana/wallet-adapter-wallets";
 
 import "@solana/wallet-adapter-react-ui/styles.css";
+import { clusterApiUrl } from "@solana/web3.js";
 
-// Endpoints configuration
-const LOCALHOST_ENDPOINT = "http://127.0.0.1:8899";
-// const DEVNET_ENDPOINT = "https://api.devnet.solana.com";
+// Récupérer l'environnement depuis les variables d'environnement
+const SOLANA_NETWORK = process.env.NEXT_PUBLIC_SOLANA_NETWORK || "devnet";
 
+// Définir l'endpoint en fonction de l'environnement
+const endpoint =
+  SOLANA_NETWORK === "localhost"
+    ? "http://127.0.0.1:8899"
+    : clusterApiUrl("devnet");
 export default function AppWalletProvider({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  // Pour le développement local
-  const endpoint = useMemo(() => LOCALHOST_ENDPOINT, []);
-
-  // Pour devnet
-  // const endpoint = useMemo(() => DEVNET_ENDPOINT, []);
+  console.log(SOLANA_NETWORK);
+  const network = endpoint;
 
   const wallets = useMemo(() => [], []);
 
   return (
-    <ConnectionProvider endpoint={endpoint}>
+    <ConnectionProvider endpoint={network}>
       <WalletProvider wallets={wallets} autoConnect>
         <WalletModalProvider>{children}</WalletModalProvider>
       </WalletProvider>


### PR DESCRIPTION
## feat(env): ajout de `NEXT_PUBLIC_SOLANA_NETWORK` pour basculer entre Devnet et Localhost

---

### 📝 Description de la fonctionnalité

Ajout d'une variable d’environnement `NEXT_PUBLIC_SOLANA_NETWORK` permettant de choisir dynamiquement entre **Devnet** et **Localhost**, afin d’éviter les modifications manuelles dans le code source (`AppWalletProvider.tsx`).

---

### 🎯 Problème ou besoin

Le `endpoint` Solana RPC était codé en dur, ce qui obligeait les développeurs à commenter/décommenter manuellement selon l’environnement. Cela introduisait un risque d’erreur et nuisait à la fluidité du développement.

---

### 💡 Solution apportée

- Ajout de la variable `NEXT_PUBLIC_SOLANA_NETWORK` dans `.env.local` :
  ```env
  # Exemple d'utilisation
  NEXT_PUBLIC_SOLANA_NETWORK=devnet
  # ou
  NEXT_PUBLIC_SOLANA_NETWORK=localhost
