### PR TITLE
feat(front): display proposals as list and add typewriter slogan

### DIFF
--- a/front/app/[locale]/page.tsx
+++ b/front/app/[locale]/page.tsx
@@ -151,7 +151,7 @@ export default function Home() {
       <div className="text-center mb-6"> {/* Container for centering */}
         <TypewriterEffect
           words={sloganWords}
-          className="text-xl text-gray-200"
+          className="text-xl"
           cursorClassName="bg-white" // Set cursor to white
         />
       </div>

--- a/front/app/[locale]/page.tsx
+++ b/front/app/[locale]/page.tsx
@@ -3,6 +3,7 @@
 import { ActiveProposalsView } from "@/components/home/ActiveProposalsView";
 import { PreviousEpochsView } from "@/components/home/PreviousEpochsView";
 import { ViewModeToggle } from "@/components/home/ViewModeToggle";
+import { TypewriterEffect } from "@/components/ui/typewriter-effect";
 
 import {
   EpochState,
@@ -117,9 +118,9 @@ export default function Home() {
           setSelectedEpochDetails(null); // Ensure details are null if no epochs
         }
 
-        // Reload proposals after epoch change
-        const proposals = await getAllProposals();
-        setAllProposals(proposals);
+        // NE PAS recharger les propositions ici. Le filtrage s'en chargera.
+        // const proposals = await getAllProposals();
+        // setAllProposals(proposals);
       } catch (error) {
         console.error("Failed to fetch epochs:", error);
         setSelectedEpochDetails(null); // Reset on error
@@ -131,10 +132,32 @@ export default function Home() {
     initializeEpoch();
   }, [getAllEpochs, viewMode]);
 
+  // Prepare words for TypewriterEffect
+  const sloganWords = [
+    { text: "10" },
+    { text: "tokens" },
+    { text: "rise." },
+    { text: "The" },
+    { text: "rest" },
+    { text: "burn.", className: "text-red-600 dark:text-red-500" }, // Changed to red color
+    { text: "Choose" },
+    { text: "your" },
+    { text: "side." }, // Removed specific class, will use base color
+  ];
+
   return (
-    <div className="container mx-auto px-4 py-8">
-      {/* Toggle Switch */}
-      <div className="flex justify-center mb-8">
+    <div className="container mx-auto px-4 pt-4 pb-8">
+      {/* Slogan Section with Typewriter Effect */}
+      <div className="text-center mb-6"> {/* Container for centering */}
+        <TypewriterEffect
+          words={sloganWords}
+          className="text-xl text-gray-200"
+          cursorClassName="bg-white" // Set cursor to white
+        />
+      </div>
+
+      {/* Toggle Switch: Align to the right */}
+      <div className="flex justify-end mb-4">
         <ViewModeToggle viewMode={viewMode} onChangeMode={setViewMode} />
       </div>
 

--- a/front/app/globals.css
+++ b/front/app/globals.css
@@ -70,7 +70,7 @@
   --sidebar-accent: oklch(0.97 0 0);
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --sidebar-ring: oklch(0.556 0 0);
 }
 
 .dark {
@@ -106,3 +106,99 @@
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
 }
+
+/* --- Suppression de l'ancienne approche (wrapper/content) --- */
+/*
+@keyframes bg-spin { to { --border-angle: 1turn; } }
+.gradient-border-wrap { ... }
+.gradient-border-wrap::before { ... }
+.gradient-content { ... }
+.gradient-border-green { ... }
+.gradient-border-dark-green { ... }
+.gradient-border-orange { ... }
+*/
+
+/* --- Début: Code fourni par l'utilisateur (basé sur le masquage) --- */
+
+@property --border-angle {
+  syntax: '<angle>';
+  inherits: false;
+  initial-value: 0deg;
+}
+
+@keyframes bg-spin { to { --border-angle: 1turn; } }
+
+/* Classe de base: UNIQUEMENT structure, PAS de ::before ni de couleurs par défaut */
+.gradient-border {
+  --border-size: 2px;
+  --border-angle: 0turn;
+  position: relative;
+  /* Le fond et le radius sont appliqués via Tailwind sur le même élément */
+}
+
+/* Règles ::before SPÉCIFIQUES pour chaque couleur */
+
+.gradient-border-green::before,
+.gradient-border-blue::before,
+.gradient-border-orange::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: var(--border-size);
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+          mask-composite: exclude;
+  animation: bg-spin 8s linear infinite;
+  z-index: 0;
+}
+
+/* Définition du conic-gradient pour chaque couleur */
+
+.gradient-border-green::before { /* Top 3 */
+  background: conic-gradient(
+    from var(--border-angle),
+    rgba(71, 85, 105, 0.3) 80%,
+    rgb(16, 185, 129) 86%,    /* green-500 */
+    rgb(66, 222, 164) 90%,   /* green-400 */
+    rgb(16, 185, 129) 94%,    /* green-500 */
+    rgba(71, 85, 105, 0.3)
+  );
+}
+
+.gradient-border-blue::before { /* 4-7 - Test avec du bleu */
+  background: conic-gradient(
+    from var(--border-angle),
+    rgba(71, 85, 105, 0.2) 80%,
+    rgb(1, 79, 32) 86%,      /* green-800 */
+    rgb(1, 111, 20) 90%,     /* green-900 */
+    rgb(2, 87, 32) 94%,      /* green-800 */
+    rgba(71, 85, 105, 0.2)
+  );
+}
+
+.gradient-border-orange::before { /* 8-10 */
+  background: conic-gradient(
+    from var(--border-angle),
+    rgba(71, 85, 105, 0.3) 80%,
+    rgb(234, 88, 12) 86%,     /* orange-600 */
+    rgb(247, 127, 42) 90%,    /* orange-500 */
+    rgb(234, 88, 12) 94%,     /* orange-600 */
+    rgba(71, 85, 105, 0.3)
+  );
+}
+
+/* --- Supprimer l'ancien .gradient-border::before et les anciennes classes de couleur --- */
+/*
+.gradient-border::before { }
+.gradient-border-green { }
+.gradient-border-dark-green::before { } // Commenté car remplacé par blue pour test 
+.gradient-border-orange { }
+*/
+
+/* --- Fin du code --- */

--- a/front/components/home/ActiveProposalsView.tsx
+++ b/front/components/home/ActiveProposalsView.tsx
@@ -1,9 +1,11 @@
 import EpochSelector from "@/components/epoch/EpochSelector";
 import { ProposalCard } from "@/components/home/ProposalCard";
 import { EpochState, ProposalState } from "@/context/ProgramContext";
+import { cn } from "@/lib/utils";
 import { format } from "date-fns";
 import { enUS, fr } from "date-fns/locale";
 import { useTranslations } from "next-intl";
+import { useMemo } from "react";
 
 type ActiveProposalsViewProps = {
   selectedEpochId?: string;
@@ -24,63 +26,87 @@ export function ActiveProposalsView({
 }: ActiveProposalsViewProps) {
   const t = useTranslations("Home");
 
+  const sortedFilteredProposals = useMemo(() => {
+    return [...filteredProposals].sort((a, b) => b.solRaised - a.solRaised);
+  }, [filteredProposals]);
+
   return (
     <>
-      <EpochSelector
-        selectedEpochId={selectedEpochId}
-        onSelect={onSelectEpoch}
-        activeOnly
-      />
-      {selectedEpochDetails && (
-        <div className="mt-6 mb-8 p-6 bg-gray-800/50 rounded-xl border border-gray-700">
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <div className="text-center">
-              <h3 className="text-sm text-gray-400 mb-1">{t("epochStart")}</h3>
-              <p className="text-lg font-semibold">
-                {format(
-                  new Date(selectedEpochDetails.startTime * 1000),
-                  "PPp",
-                  {
+      {/* Container for Epoch Selector and Details Card */}
+      <div className="flex flex-wrap items-center justify-between gap-4 mb-6">
+        <EpochSelector
+          selectedEpochId={selectedEpochId}
+          onSelect={onSelectEpoch}
+          activeOnly
+        />
+
+        {/* Epoch Details Card - remove its own margins */}
+        {selectedEpochDetails && (
+          <div className="px-6 py-2 bg-gray-800/50 rounded-xl border border-gray-700 flex-grow md:flex-grow-0">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div className="text-center">
+                <h3 className="text-sm text-gray-400 mb-1">{t("epochStart")}</h3>
+                <p className="text-lg font-semibold">
+                  {format(
+                    new Date(selectedEpochDetails.startTime * 1000),
+                    "PPp",
+                    {
+                      locale: locale === "fr" ? fr : enUS,
+                    }
+                  )}
+                </p>
+              </div>
+
+              <div className="text-center">
+                <h3 className="text-sm text-gray-400 mb-1">{t("epochEnd")}</h3>
+                <p className="text-lg font-semibold">
+                  {format(new Date(selectedEpochDetails.endTime * 1000), "PPp", {
                     locale: locale === "fr" ? fr : enUS,
-                  }
-                )}
-              </p>
-            </div>
+                  })}
+                </p>
+              </div>
 
-            <div className="text-center">
-              <h3 className="text-sm text-gray-400 mb-1">{t("epochEnd")}</h3>
-              <p className="text-lg font-semibold">
-                {format(new Date(selectedEpochDetails.endTime * 1000), "PPp", {
-                  locale: locale === "fr" ? fr : enUS,
-                })}
-              </p>
-            </div>
-
-            <div className="text-center">
-              <h3 className="text-sm text-gray-400 mb-1">
-                {t("proposalsCount")}
-              </h3>
-              <p className="text-lg font-semibold">
-                {t("proposalCount", { count: filteredProposals.length })}
-              </p>
+              <div className="text-center">
+                <h3 className="text-sm text-gray-400 mb-1">
+                  {t("proposalsCount")}
+                </h3>
+                <p className="text-lg font-semibold">
+                  {t("proposalCount", { count: filteredProposals.length })}
+                </p>
+              </div>
             </div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
 
       {loading ? (
         <div className="flex justify-center py-8">
           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white"></div>
         </div>
-      ) : filteredProposals.length > 0 ? (
-        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-          {filteredProposals.map((proposal) => (
-            <ProposalCard
-              key={proposal.publicKey.toString()}
-              proposal={proposal}
-              locale={locale}
-            />
-          ))}
+      ) : sortedFilteredProposals.length > 0 ? (
+        <div className="flex flex-col gap-4">
+          {sortedFilteredProposals.map((proposal, index) => {
+            let borderClass = "";
+
+            if (index < 3) {
+              borderClass = "gradient-border gradient-border-green";
+            } else if (index < 7) {
+              borderClass = "gradient-border gradient-border-blue";
+            } else if (index < 10) {
+              borderClass = "gradient-border gradient-border-blue";
+            } else {
+              borderClass = "border-1 border-red-900";
+            }
+
+            return (
+              <ProposalCard
+                key={proposal.publicKey.toString()}
+                proposal={proposal}
+                locale={locale}
+                className={borderClass}
+              />
+            );
+          })}
         </div>
       ) : (
         <div className="text-center py-8 text-gray-400">

--- a/front/components/home/ProposalCard.tsx
+++ b/front/components/home/ProposalCard.tsx
@@ -2,61 +2,99 @@ import { ProposalState } from "@/context/ProgramContext";
 import { LAMPORTS_PER_SOL } from "@solana/web3.js";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
+import { cn } from "@/lib/utils";
 
 type ProposalCardProps = {
   proposal: ProposalState;
   locale: string | undefined;
+  className?: string; // Expects border classes (static or gradient)
 };
 
-export function ProposalCard({ proposal, locale }: ProposalCardProps) {
+export function ProposalCard({ proposal, locale, className }: ProposalCardProps) {
   const t = useTranslations("Home");
 
-  return (
-    <div
-      className="bg-gray-800/50 rounded-xl overflow-hidden border border-gray-700 
-      hover:border-gray-500 transition-all duration-200 shadow-lg hover:shadow-xl
-      transform hover:-translate-y-1"
-    >
-      {/* Image placeholder - à remplacer par l'image réelle */}
-      <div className="h-48 bg-gray-700 animate-pulse"></div>
-
-      <div className="p-6 space-y-4">
-        <div className="space-y-2">
-          <h3 className="text-xl font-bold text-gray-100">
-            {proposal.tokenName}
-          </h3>
-          <div className="flex justify-between items-center">
-            <p className="text-sm text-gray-400">${proposal.tokenSymbol}</p>
-            <p className="text-xs text-gray-500">
-              {t("by")} {proposal.creator.toString().slice(0, 4)}...
-              {proposal.creator.toString().slice(-4)}
-            </p>
-          </div>
-        </div>
-
-        <div className="flex justify-between items-center text-sm text-gray-300">
-          <span>
+  // Card content definition remains the same
+  const CardContent = (
+    <>
+      <div className="w-12 h-12 bg-gray-700 rounded-lg mr-4 flex-shrink-0 animate-pulse"></div>
+      <div className="flex-grow mr-4 space-y-1">
+        <p className="font-bold text-lg text-gray-100">${proposal.tokenSymbol}</p>
+        <h3 className="text-md text-gray-200">{proposal.tokenName}</h3>
+        <p className="text-xs text-gray-500 pt-1">
+          {t("by")} {proposal.creator.toString().slice(0, 4)}...
+          {proposal.creator.toString().slice(-4)}
+        </p>
+      </div>
+      {/* Section Droite : Réorganisée en Ligne (Bouton à gauche, Stats à droite) */}
+      <div className="flex items-center gap-4 ml-auto flex-shrink-0">
+        {/* Bouton Support (maintenant à gauche dans cette section) */}
+        <Link
+          href={`/${locale || "en"}/proposal/${proposal.publicKey.toString()}#support`}
+          className={cn(
+            "px-4 py-2",
+            "bg-emerald-700",
+            "text-white rounded-lg",
+            "text-sm flex-shrink-0 whitespace-nowrap",
+            "hover:bg-emerald-500",
+            "hover:shadow-lg hover:shadow-emerald-500/50",
+            "transition-all duration-200"
+          )}
+        >
+          {t("supportProject")}
+        </Link>
+        {/* Colonne interne pour les stats (SOL levés et Contributions) */}
+        <div className="flex flex-col items-end space-y-0.5"> {/* Espace vertical réduit */}
+          <span className="text-base font-semibold text-gray-100 whitespace-nowrap">
             {t("solanaRaised", {
               amount: (proposal.solRaised / LAMPORTS_PER_SOL).toFixed(2),
             })}
           </span>
-          <span className="text-gray-400">
+          <span className="text-xs text-gray-400 whitespace-nowrap">
             {t("totalContributions", {
               count: proposal.totalContributions,
             })}
           </span>
         </div>
-
-        <Link
-          href={`/${
-            locale || "en"
-          }/proposal/${proposal.publicKey.toString()}#support`}
-          className="block w-full text-center px-4 py-2 bg-green-600 text-white rounded-lg
-            hover:bg-green-700 transition-colors duration-200"
-        >
-          {t("supportProject")}
-        </Link>
       </div>
-    </div>
+    </>
   );
+
+  // Check if the passed className includes 'gradient-border-'
+  const hasGradientBorder = className?.includes("gradient-border-");
+
+  if (hasGradientBorder) {
+    // Structure simple : un seul div avec .gradient-border, la couleur, le fond, le layout, le padding interne
+    return (
+      <div
+        className={cn(
+          "gradient-border", // Classe CSS de base pour l'effet
+          className,         // Classe de couleur (ex: "gradient-border-green")
+          "bg-gray-800/50",  // Fond réel de la carte
+          "rounded-xl",      // Applique le radius (sera hérité par ::before)
+          "flex items-center", // Layout du contenu
+          "px-4 py-1"        // Padding INTERNE global réduit (py-2 -> py-1)
+          // Le CSS .gradient-border::before ajoutera le padding EXTERNE pour la bordure
+        )}
+      >
+        {/* Le contenu est directement enfant. Le z-index du ::before devrait le placer derrière ce contenu */}
+        <div className="relative z-10 flex items-center w-full"> {/* Ajout d'un wrapper pour z-index */} 
+          {CardContent} 
+        </div>
+      </div>
+    );
+  } else {
+    // Structure pour bordure statique (padding global réduit aussi)
+    return (
+      <div
+        className={cn(
+          "flex items-center bg-gray-800/50 px-4 py-1 rounded-xl", // Padding global réduit (py-2 -> py-1)
+          className ? className : "border border-gray-700",
+          "hover:border-gray-500 transition-all duration-200 shadow-md hover:shadow-lg",
+          "transform hover:-translate-y-1"
+        )}
+      >
+        {CardContent}
+      </div>
+    );
+  }
 }

--- a/front/components/home/ViewModeToggle.tsx
+++ b/front/components/home/ViewModeToggle.tsx
@@ -16,7 +16,7 @@ export function ViewModeToggle({
           onClick={() => onChangeMode("active")}
           className={`relative z-10 px-6 py-2 rounded-full transition-all duration-200 ${
             viewMode === "active"
-              ? "text-white font-medium"
+              ? "text-black font-medium"
               : "text-gray-300 hover:text-white"
           }`}
         >
@@ -26,14 +26,14 @@ export function ViewModeToggle({
           onClick={() => onChangeMode("previous")}
           className={`relative z-10 px-6 py-2 rounded-full transition-all duration-200 ${
             viewMode === "previous"
-              ? "text-white font-medium"
+              ? "text-black font-medium"
               : "text-gray-300 hover:text-white"
           }`}
         >
           Previous Epochs
         </button>
         <div
-          className="absolute inset-y-0 w-1/2 bg-green-600/90 rounded-full transition-transform duration-200 shadow-lg"
+          className="absolute inset-y-0 w-1/2 bg-white rounded-full transition-transform duration-200 shadow-lg"
           style={{
             transform: `translateX(${viewMode === "previous" ? "100%" : "0"})`,
           }}

--- a/front/components/ui/typewriter-effect.tsx
+++ b/front/components/ui/typewriter-effect.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { motion, stagger, useAnimate, useInView } from "motion/react";
+import { useEffect } from "react";
+
+export const TypewriterEffect = ({
+  words,
+  className,
+  cursorClassName,
+}: {
+  words: {
+    text: string;
+    className?: string;
+  }[];
+  className?: string;
+  cursorClassName?: string;
+}) => {
+  // split text inside of words into array of characters
+  const wordsArray = words.map((word) => {
+    return {
+      ...word,
+      text: word.text.split(""),
+    };
+  });
+
+  const [scope, animate] = useAnimate();
+  const isInView = useInView(scope);
+  useEffect(() => {
+    if (isInView) {
+      animate(
+        "span",
+        {
+          display: "inline-block",
+          opacity: 1,
+          width: "fit-content",
+        },
+        {
+          duration: 0.3,
+          delay: stagger(0.1),
+          ease: "easeInOut",
+        }
+      );
+    }
+  }, [isInView]);
+
+  const renderWords = () => {
+    return (
+      <motion.div ref={scope} className="inline">
+        {wordsArray.map((word, idx) => {
+          return (
+            <div key={`word-${idx}`} className="inline-block">
+              {word.text.map((char, index) => (
+                <motion.span
+                  initial={{}}
+                  key={`char-${index}`}
+                  className={cn(
+                    `dark:text-white text-black opacity-0 hidden`,
+                    word.className
+                  )}
+                >
+                  {char}
+                </motion.span>
+              ))}
+              &nbsp;
+            </div>
+          );
+        })}
+      </motion.div>
+    );
+  };
+  return (
+    <div
+      className={cn(
+        "text-base sm:text-xl md:text-3xl lg:text-5xl font-bold text-center",
+        className
+      )}
+    >
+      {renderWords()}
+      <motion.span
+        initial={{
+          opacity: 0,
+        }}
+        animate={{
+          opacity: 1,
+        }}
+        transition={{
+          duration: 0.8,
+          repeat: Infinity,
+          repeatType: "reverse",
+        }}
+        className={cn(
+          "inline-block rounded-sm w-[4px] h-4 md:h-6 lg:h-10 bg-blue-500",
+          cursorClassName
+        )}
+      ></motion.span>
+    </div>
+  );
+};
+
+export const TypewriterEffectSmooth = ({
+  words,
+  className,
+  cursorClassName,
+}: {
+  words: {
+    text: string;
+    className?: string;
+  }[];
+  className?: string;
+  cursorClassName?: string;
+}) => {
+  // split text inside of words into array of characters
+  const wordsArray = words.map((word) => {
+    return {
+      ...word,
+      text: word.text.split(""),
+    };
+  });
+  const renderWords = () => {
+    return (
+      <div>
+        {wordsArray.map((word, idx) => {
+          return (
+            <div key={`word-${idx}`} className="inline-block">
+              {word.text.map((char, index) => (
+                <span
+                  key={`char-${index}`}
+                  className={cn(`dark:text-white text-black `, word.className)}
+                >
+                  {char}
+                </span>
+              ))}
+              &nbsp;
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  return (
+    <div className={cn("flex space-x-1 my-6", className)}>
+      <motion.div
+        className="overflow-hidden pb-2"
+        initial={{
+          width: "0%",
+        }}
+        whileInView={{
+          width: "fit-content",
+        }}
+        transition={{
+          duration: 2,
+          ease: "linear",
+          delay: 1,
+        }}
+      >
+        <div
+          className="text-xs sm:text-base md:text-xl lg:text:3xl xl:text-5xl font-bold"
+          style={{
+            whiteSpace: "nowrap",
+          }}
+        >
+          {renderWords()}{" "}
+        </div>{" "}
+      </motion.div>
+      <motion.span
+        initial={{
+          opacity: 0,
+        }}
+        animate={{
+          opacity: 1,
+        }}
+        transition={{
+          duration: 0.8,
+
+          repeat: Infinity,
+          repeatType: "reverse",
+        }}
+        className={cn(
+          "block rounded-sm w-[4px]  h-4 sm:h-6 xl:h-12 bg-blue-500",
+          cursorClassName
+        )}
+      ></motion.span>
+    </div>
+  );
+};

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -1,4 +1,4 @@
-import { clsx, type ClassValue } from "clsx";
+import { ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -23,6 +23,7 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "lucide-react": "^0.487.0",
+        "motion": "^12.9.4",
         "next": "15.2.4",
         "next-intl": "^4.0.2",
         "next-themes": "^0.4.6",
@@ -11669,6 +11670,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.9.4",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.9.4.tgz",
+      "integrity": "sha512-yaeGDmGQ3eCQEwZ95/pRQMaSh/Q4E2CK6JYOclG/PdjyQad0MULJ+JFVV8911Fl5a6tF6o0wgW8Dpl5Qx4Adjg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.9.4",
+        "motion-utils": "^12.9.4",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -14187,6 +14215,47 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.9.4",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.9.4.tgz",
+      "integrity": "sha512-ZMKNnhWylaIbtFmU+scDxdldk//3Rn/8B+dcDhIpGlixAl7yhiLx1WXyGD4TSJZf3sDU6yrnu3L3FWGFo4fTEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.9.4",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.9.4",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.9.4.tgz",
+      "integrity": "sha512-25TWkQPj5I18m+qVjXGtCsxboY11DaRC5HMjd29tHKExazW4Zf4XtAagBdLpyKsVuAxEQ6cx5/E4AB21PFpLnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.9.4"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.9.4",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.9.4.tgz",
+      "integrity": "sha512-BW3I65zeM76CMsfh3kHid9ansEJk9Qvl+K5cu4DVHKGsI52n76OJ4z2CUJUV+Mn3uEP9k1JJA3tClG0ggSrRcg==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/front/package.json
+++ b/front/package.json
@@ -24,6 +24,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.487.0",
+    "motion": "^12.9.4",
     "next": "15.2.4",
     "next-intl": "^4.0.2",
     "next-themes": "^0.4.6",


### PR DESCRIPTION
# feat(front): Display proposals as list with animated slogan

## 📌 Description

-   **Contexte** : La page d'accueil affichait les propositions actives sous forme de grille, ce qui pouvait devenir moins lisible avec un grand nombre de propositions par époque.
-   **Problème résolu** : Améliorer la densité d'information et la présentation visuelle des propositions actives sur la page d'accueil.
-   **Solution apportée** :
    *   Modification de l'affichage des propositions pour une liste verticale (`flex-col`).
    *   Réorganisation et ajustement du style du composant `ProposalCard` pour un format de ligne optimisé et une hauteur réduite.
    *   Ajout d'un slogan animé en haut de la page utilisant le composant `TypewriterEffect`.
    *   Implémentation de bordures dégradées animées pour les 10 premières propositions, avec des couleurs différentes selon le classement (Top 3, 4-10).
    *   Ajustement du style du bouton "Support".

## ✅ Type de changement

Cochez les options pertinentes :

-   [ ] 🐛 Correction de bug
-   [x] ✨ Nouvelle fonctionnalité
-   [x] 🔧 Refactoring
-   [ ] 📝 Mise à jour de la documentation
-   [ ] 🚀 Amélioration des performances
-   [ ] ✅ Ajout de tests
-   [ ] 🔒 Amélioration de la sécurité
-   [ ] Autre (précisez) :

## 🔍 Comment tester cette PR ?

Fournissez des instructions pour tester les modifications :

1.  Lancer l'application frontend (cd front puis npm run dev)
2.  Naviguer vers la page d'accueil.
3.  Utiliser le sélecteur d'époque pour choisir l'époque **#215224551151991**.
4.  **Résultats attendus** :
    *   Les 12 propositions de cette époque s'affichent sous forme de liste verticale.
    *   Le slogan animé "10 tokens rise..." s'affiche en haut.
    *   Les 3 premières propositions ont une bordure vert clair animée.
    *   Les propositions 4 à 7 ont une bordure d'une autre couleur (actuellement bleu pour test, ou vert très foncé si remis).
    *   Les propositions 8 à 10 ont une bordure orange animée.
    *   Les cartes ont une hauteur réduite et le bouton "Support" a le nouveau style et effet de survol.

## 📎 Liens associés

-   **Issues liées** : #94
-   **Documentation** : N/A
-   **Autres PRs** : N/A

## 👥 Revue

-   **Relecteurs suggérés** : @pylejeune @alexandre-bourdois 
-   **Domaines concernés** : `front/app/[locale]/page.tsx`, `front/components/home/ActiveProposalsView.tsx`, `front/components/home/ProposalCard.tsx`, `front/app/globals.css`, `front/components/ui/typewriter-effect.tsx`

## 🧪 Checklist

-   [x] Le code compile sans erreur
-   [ ] Les tests unitaires passent (non applicable directement)
-   [ ] La documentation est à jour (non applicable)
-   [x] Les dépendances sont à jour
-   [x] La PR est prête pour la revue

## Composants ajoutés

-   Ajout du composant `front/components/ui/typewriter-effect.tsx` (basé sur Aceternity UI) pour l'animation du slogan.

## 📸 Captures d'écran (si applicable)

![image](https://github.com/user-attachments/assets/d2ae33f5-1ba4-40fc-9446-df713e49c7ce)

## 🗒️ Notes complémentaires

-   La couleur de la bordure pour les propositions 4-7 est actuellement définie sur bleu dans `globals.css` à des fins de test de différenciation. Elle devra être remise à une teinte de vert foncé si souhaité avant le merge.