### PR TITLE
44 feature afficher les proposal support dun proposal token

### DIFF
--- a/front/app/[locale]/proposal/[id]/page.tsx
+++ b/front/app/[locale]/proposal/[id]/page.tsx
@@ -370,24 +370,7 @@ export default function ProposalDetailPage() {
           </div>
 
           {/* Supporters Section */}
-          <div className="bg-gray-800/50 p-4 rounded-lg">
-            <h2 className="text-lg font-medium mb-4">
-              {t("supporters")}
-              {supports.length > 20 && (
-                <span className="text-sm text-gray-400 ml-2">
-                  ({t("showingTop20")})
-                </span>
-              )}
-            </h2>
-
-            {isLoadingSupports ? (
-              <div className="flex justify-center py-4">
-                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white" />
-              </div>
-            ) : (
-              <ProposalSupportList proposal={proposal} />
-            )}
-          </div>
+          <ProposalSupportList proposal={proposal} />
         </div>
       </div>
     </div>

--- a/front/app/[locale]/proposal/[id]/page.tsx
+++ b/front/app/[locale]/proposal/[id]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import ProposalSupportList from "@/components/proposal/ProposalSupportList";
 import BackButton from "@/components/ui/BackButton";
 import {
   ProposalStatus,
@@ -15,7 +16,7 @@ import { useParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 
-type DetailedProposal = {
+export type DetailedProposal = {
   id: string;
   name: string;
   ticker: string;
@@ -384,104 +385,7 @@ export default function ProposalDetailPage() {
                 <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white" />
               </div>
             ) : (
-              <div className="space-y-4">
-                {[...supports]
-                  .map((support) => ({
-                    ...support,
-                    totalTokens:
-                      support.user.toString() === proposal.creator.toString()
-                        ? support.tokenAllocation + proposal.creatorAllocation
-                        : support.tokenAllocation,
-                  }))
-                  //Sort by invested sol amount (only top 20)
-                  .sort((a, b) => b.amount - a.amount)
-                  .slice(0, 20)
-                  .map((support, index) => {
-                    const isCreator =
-                      support.user.toString() === proposal.creator.toString();
-                    return (
-                      <div
-                        key={index}
-                        className="bg-gray-900/50 p-3 rounded-lg flex justify-between items-center"
-                      >
-                        <div className="flex items-center gap-4">
-                          <span className="text-sm text-gray-500">
-                            #{index + 1}
-                          </span>
-                          <div>
-                            <div className="flex items-center gap-2">
-                              <p className="font-mono text-sm text-gray-400">
-                                {support.user.toBase58().slice(0, 4)}...
-                                {support.user.toBase58().slice(-4)}
-                              </p>
-                              {isCreator && (
-                                <span
-                                  className="text-green-400 cursor-help"
-                                  title={t("creatorWallet")}
-                                >
-                                  🌱
-                                </span>
-                              )}
-                            </div>
-                            <p className="text-sm text-gray-300">
-                              {new Date(support.timestamp).toLocaleDateString()}
-                            </p>
-                          </div>
-                        </div>
-                        <div className="text-right">
-                          <p className="text-lg font-medium">
-                            {support.amount.toLocaleString(locale, {
-                              minimumFractionDigits: 2,
-                              maximumFractionDigits: 2,
-                            })}{" "}
-                            SOL
-                          </p>
-                          <p className="text-sm text-gray-400">
-                            {support.tokenAllocation.toLocaleString(locale, {
-                              maximumFractionDigits: 2,
-                            })}
-                            % {t("ofTokens")}
-                            {isCreator && (
-                              <span className="ml-1 text-green-400">
-                                (+{proposal.creatorAllocation}%{" "}
-                                {t("creatorAllocation")})
-                              </span>
-                            )}
-                          </p>
-                        </div>
-                      </div>
-                    );
-                  })}
-                {supports.length === 0 && proposal.creatorAllocation > 0 && (
-                  <div className="bg-gray-900/50 p-3 rounded-lg flex justify-between items-center">
-                    <div className="flex items-center gap-4">
-                      <span className="text-sm text-gray-500">#1</span>
-                      <div>
-                        <div className="flex items-center gap-2">
-                          <p className="font-mono text-sm text-gray-400">
-                            {proposal.creator.toBase58().slice(0, 4)}...
-                            {proposal.creator.toBase58().slice(-4)}
-                          </p>
-                          <span
-                            className="text-green-400 cursor-help"
-                            title={t("creatorWallet")}
-                          >
-                            🌱
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                    <div className="text-right">
-                      <p className="text-lg font-medium">0.00 SOL</p>
-                      <p className="text-sm text-gray-400">
-                        <span className="text-green-400">
-                          {proposal.creatorAllocation}% {t("creatorAllocation")}
-                        </span>
-                      </p>
-                    </div>
-                  </div>
-                )}
-              </div>
+              <ProposalSupportList proposal={proposal} />
             )}
           </div>
         </div>

--- a/front/app/[locale]/proposal/[id]/page.tsx
+++ b/front/app/[locale]/proposal/[id]/page.tsx
@@ -1,17 +1,19 @@
 "use client";
 
 import BackButton from "@/components/ui/BackButton";
-import { useProgram } from "@/context/ProgramContext";
+import {
+  ProposalStatus,
+  ProposalSupport,
+  useProgram,
+} from "@/context/ProgramContext";
 import { ipfsToHttp } from "@/utils/ImageStorage";
 import { useWallet } from "@solana/wallet-adapter-react";
 import { PublicKey } from "@solana/web3.js";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import { useParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
-
-type ProposalStatus = "active" | "validated" | "rejected";
 
 type DetailedProposal = {
   id: string;
@@ -32,96 +34,115 @@ type DetailedProposal = {
 };
 
 export default function ProposalDetailPage() {
-  // Hooks and context
+  // 1. Hooks
   const t = useTranslations("ProposalDetail");
   const { locale, id } = useParams();
   const { publicKey } = useWallet();
+  const { getProposalDetails, supportProposal, getProposalSupports } =
+    useProgram();
+
+  // 2. States
   const [supportAmount, setSupportAmount] = useState<string>("");
-  const { getProposalDetails, supportProposal } = useProgram();
   const [proposal, setProposal] = useState<DetailedProposal | null>(null);
   const [loading, setLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [supports, setSupports] = useState<ProposalSupport[]>([]);
+  const [isLoadingSupports, setIsLoadingSupports] = useState(true);
 
-  // Load proposal details on mount
-  useEffect(() => {
-    const loadProposal = async () => {
-      try {
-        setLoading(true);
-        if (!id) {
-          toast.error(t("proposalNotFound"));
-          return;
-        }
-
-        // Wait for program initialization
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-
-        const details = await getProposalDetails(id as string);
-        if (!details) {
-          toast.error(t("proposalNotFound"));
-          return;
-        }
-
-        // Format proposal data
-        const formattedProposal: DetailedProposal = {
-          id: id as string,
-          name: details.tokenName,
-          ticker: details.tokenSymbol,
-          description: details.description,
-          imageUrl: details.imageUrl,
-          epoch_id: details.epochId,
-          solRaised: details.solRaised,
-          creator: details.creator,
-          totalSupply: details.totalSupply,
-          creatorAllocation: details.creatorAllocation,
-          supporterAllocation: details.supporterAllocation,
-          status: details.status as ProposalStatus,
-          totalContributions: details.totalContributions,
-          lockupPeriod: details.lockupPeriod,
-          publicKey: details.publicKey,
-        };
-
-        setProposal(formattedProposal);
-      } catch (error) {
-        console.error("Failed to load proposal:", error);
-        if ((error as Error).message === "Program not initialized") {
-          // Retry after delay if program not ready
-          setTimeout(loadProposal, 1000);
-        } else {
-          toast.error(t("errorLoadingProposal"));
-        }
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    loadProposal();
-  }, [id, getProposalDetails]);
-
-  // Helper function to format large numbers
-  const formatNumber = (number: number) => {
-    return number.toLocaleString(locale === "fr" ? "fr-FR" : "en-US");
-  };
-
-  // Handle support form submission
-  const handleSupport = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!proposal || !supportAmount) return;
+  // 3. Callbacks
+  const loadProposal = useCallback(async () => {
+    if (!id || !getProposalDetails) return;
 
     try {
-      setIsSubmitting(true);
-      await supportProposal(
-        proposal.publicKey.toString(),
-        parseFloat(supportAmount)
-      );
-      toast.success(t("supportSuccess"));
-      setSupportAmount("");
-    } catch (error: any) {
-      console.error("Support failed:", error);
-      toast.error(error.message || t("supportError"));
+      setLoading(true);
+      const details = await getProposalDetails(id as string);
+
+      if (!details) {
+        toast.error(t("proposalNotFound"));
+        return;
+      }
+
+      setProposal({
+        id: id as string,
+        name: details.tokenName,
+        ticker: details.tokenSymbol,
+        description: details.description,
+        imageUrl: details.imageUrl,
+        epoch_id: details.epochId,
+        solRaised: details.solRaised,
+        creator: details.creator,
+        totalSupply: details.totalSupply,
+        creatorAllocation: details.creatorAllocation,
+        supporterAllocation: details.supporterAllocation,
+        status: details.status as ProposalStatus,
+        totalContributions: details.totalContributions,
+        lockupPeriod: details.lockupPeriod,
+        publicKey: details.publicKey,
+      });
+    } catch (error) {
+      toast.error(t("errorLoadingProposal"));
     } finally {
-      setIsSubmitting(false);
+      setLoading(false);
     }
-  };
+  }, [id, getProposalDetails, t]);
+
+  const loadSupports = useCallback(async () => {
+    if (!proposal?.publicKey || !getProposalSupports) return;
+
+    try {
+      setIsLoadingSupports(true);
+      const proposalSupports = await getProposalSupports(
+        proposal.publicKey.toString()
+      );
+      setSupports(proposalSupports);
+    } catch (error) {
+      toast.error(t("errorLoadingSupports"));
+    } finally {
+      setIsLoadingSupports(false);
+    }
+  }, [proposal?.publicKey, getProposalSupports, t]);
+
+  const handleSupport = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!proposal || !supportAmount || !supportProposal) return;
+
+      try {
+        setIsSubmitting(true);
+        await supportProposal(
+          proposal.publicKey.toString(),
+          parseFloat(supportAmount)
+        );
+        toast.success(t("supportSuccess"));
+        setSupportAmount("");
+        loadSupports();
+      } catch (error: any) {
+        toast.error(error.message || t("supportError"));
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [proposal, supportAmount, supportProposal, t, loadSupports]
+  );
+
+  // 4. Effects
+  useEffect(() => {
+    loadProposal();
+  }, [loadProposal]);
+
+  useEffect(() => {
+    if (proposal) {
+      loadSupports();
+    }
+  }, [proposal, loadSupports]);
+
+  // 5. Render helpers
+  const formatNumber = useCallback(
+    (number: number) => {
+      return number.toLocaleString(locale === "fr" ? "fr-FR" : "en-US");
+    },
+    [locale]
+  );
 
   // Helper function to get status string
   const getStatusString = (status: any): ProposalStatus => {
@@ -148,7 +169,7 @@ export default function ProposalDetailPage() {
   if (loading) {
     return (
       <div className="flex justify-center py-8">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white"></div>
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white" />
       </div>
     );
   }
@@ -170,7 +191,7 @@ export default function ProposalDetailPage() {
       <div className="bg-gray-900/50 p-3 md:p-6 rounded-lg border border-gray-800">
         {/* Header */}
         <div className="flex flex-col md:flex-row gap-8">
-          {/* Image et Infos de Base */}
+          {/* Image and Basic Info */}
           <div className="flex-shrink-0">
             <div className="relative w-full md:w-64 h-64 bg-gray-800 rounded-lg overflow-hidden">
               {proposal.imageUrl && proposal.imageUrl.length > 0 ? (
@@ -180,7 +201,6 @@ export default function ProposalDetailPage() {
                   fill
                   className="object-cover"
                   onError={(e) => {
-                    console.error("Image failed to load:", e);
                     const target = e.target as HTMLImageElement;
                     target.style.display = "none";
                   }}
@@ -346,6 +366,123 @@ export default function ProposalDetailPage() {
                 </p>
               </div>
             </div>
+          </div>
+
+          {/* Supporters Section */}
+          <div className="bg-gray-800/50 p-4 rounded-lg">
+            <h2 className="text-lg font-medium mb-4">
+              {t("supporters")}
+              {supports.length > 20 && (
+                <span className="text-sm text-gray-400 ml-2">
+                  ({t("showingTop20")})
+                </span>
+              )}
+            </h2>
+
+            {isLoadingSupports ? (
+              <div className="flex justify-center py-4">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white" />
+              </div>
+            ) : (
+              <div className="space-y-4">
+                {[...supports]
+                  .map((support) => ({
+                    ...support,
+                    totalTokens:
+                      support.user.toString() === proposal.creator.toString()
+                        ? support.tokenAllocation + proposal.creatorAllocation
+                        : support.tokenAllocation,
+                  }))
+                  //Sort by invested sol amount (only top 20)
+                  .sort((a, b) => b.amount - a.amount)
+                  .slice(0, 20)
+                  .map((support, index) => {
+                    const isCreator =
+                      support.user.toString() === proposal.creator.toString();
+                    return (
+                      <div
+                        key={index}
+                        className="bg-gray-900/50 p-3 rounded-lg flex justify-between items-center"
+                      >
+                        <div className="flex items-center gap-4">
+                          <span className="text-sm text-gray-500">
+                            #{index + 1}
+                          </span>
+                          <div>
+                            <div className="flex items-center gap-2">
+                              <p className="font-mono text-sm text-gray-400">
+                                {support.user.toBase58().slice(0, 4)}...
+                                {support.user.toBase58().slice(-4)}
+                              </p>
+                              {isCreator && (
+                                <span
+                                  className="text-green-400 cursor-help"
+                                  title={t("creatorWallet")}
+                                >
+                                  🌱
+                                </span>
+                              )}
+                            </div>
+                            <p className="text-sm text-gray-300">
+                              {new Date(support.timestamp).toLocaleDateString()}
+                            </p>
+                          </div>
+                        </div>
+                        <div className="text-right">
+                          <p className="text-lg font-medium">
+                            {support.amount.toLocaleString(locale, {
+                              minimumFractionDigits: 2,
+                              maximumFractionDigits: 2,
+                            })}{" "}
+                            SOL
+                          </p>
+                          <p className="text-sm text-gray-400">
+                            {support.tokenAllocation.toLocaleString(locale, {
+                              maximumFractionDigits: 2,
+                            })}
+                            % {t("ofTokens")}
+                            {isCreator && (
+                              <span className="ml-1 text-green-400">
+                                (+{proposal.creatorAllocation}%{" "}
+                                {t("creatorAllocation")})
+                              </span>
+                            )}
+                          </p>
+                        </div>
+                      </div>
+                    );
+                  })}
+                {supports.length === 0 && proposal.creatorAllocation > 0 && (
+                  <div className="bg-gray-900/50 p-3 rounded-lg flex justify-between items-center">
+                    <div className="flex items-center gap-4">
+                      <span className="text-sm text-gray-500">#1</span>
+                      <div>
+                        <div className="flex items-center gap-2">
+                          <p className="font-mono text-sm text-gray-400">
+                            {proposal.creator.toBase58().slice(0, 4)}...
+                            {proposal.creator.toBase58().slice(-4)}
+                          </p>
+                          <span
+                            className="text-green-400 cursor-help"
+                            title={t("creatorWallet")}
+                          >
+                            🌱
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                    <div className="text-right">
+                      <p className="text-lg font-medium">0.00 SOL</p>
+                      <p className="text-sm text-gray-400">
+                        <span className="text-green-400">
+                          {proposal.creatorAllocation}% {t("creatorAllocation")}
+                        </span>
+                      </p>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/front/components/proposal/ProposalSupportList.tsx
+++ b/front/components/proposal/ProposalSupportList.tsx
@@ -1,0 +1,132 @@
+import { DetailedProposal } from "@/app/[locale]/proposal/[id]/page";
+import { ProposalSupport, useProgram } from "@/context/ProgramContext";
+import { useTranslations } from "next-intl";
+import { useParams } from "next/navigation";
+import { useEffect, useState } from "react";
+
+type ProposalSupportListProps = {
+  proposal: DetailedProposal;
+};
+
+export default function ProposalSupportList({
+  proposal,
+}: ProposalSupportListProps) {
+  const t = useTranslations("ProposalDetail");
+  const { locale } = useParams();
+  const { getProposalSupports } = useProgram();
+  const [supports, setSupports] = useState<ProposalSupport[]>([]);
+  const [isLoadingSupports, setIsLoadingSupports] = useState(true);
+
+  useEffect(() => {
+    const loadSupports = async () => {
+      if (!proposal?.publicKey || !getProposalSupports) return;
+
+      try {
+        setIsLoadingSupports(true);
+        const proposalSupports = await getProposalSupports(
+          proposal.publicKey.toString()
+        );
+        setSupports(proposalSupports);
+      } catch (error) {
+        // Handle error if needed
+      } finally {
+        setIsLoadingSupports(false);
+      }
+    };
+
+    loadSupports();
+  }, [proposal?.publicKey, getProposalSupports]);
+
+  return (
+    <div className="bg-gray-800/50 p-4 rounded-lg">
+      <h2 className="text-lg font-medium mb-4">
+        {t("supporters")}
+        {supports.length > 20 && (
+          <span className="text-sm text-gray-400 ml-2">
+            ({t("showingTop20")})
+          </span>
+        )}
+      </h2>
+
+      {isLoadingSupports ? (
+        <div className="flex justify-center py-4">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white" />
+        </div>
+      ) : supports.length === 0 ? (
+        <div className="text-center text-gray-400 py-4">
+          {t("noSupportersYet")}
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {[...supports]
+            .map((support) => ({
+              ...support,
+              totalTokens:
+                support.user.toString() === proposal.creator.toString()
+                  ? support.tokenAllocation + proposal.creatorAllocation
+                  : support.tokenAllocation,
+            }))
+            .sort((a, b) => b.amount - a.amount)
+            .slice(0, 20)
+            .map((support, index) => {
+              const isCreator =
+                support.user.toString() === proposal.creator.toString();
+              return (
+                <div
+                  key={index}
+                  className="bg-gray-900/50 p-3 rounded-lg flex justify-between items-center"
+                >
+                  <div className="flex items-center gap-4">
+                    <span className="text-sm text-gray-500">#{index + 1}</span>
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <p className="font-mono text-sm text-gray-400">
+                          {support.user.toBase58().slice(0, 4)}...
+                          {support.user.toBase58().slice(-4)}
+                        </p>
+                        {isCreator && (
+                          <span
+                            className="text-green-400 cursor-help"
+                            title={t("creatorWallet")}
+                          >
+                            🌱
+                          </span>
+                        )}
+                      </div>
+                      <p className="text-sm text-gray-300">
+                        {new Date(support.timestamp).toLocaleDateString()}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-lg font-medium">
+                      {support.amount.toLocaleString(locale as string, {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2,
+                      })}{" "}
+                      SOL
+                    </p>
+                    <p className="text-sm text-gray-400">
+                      {support.tokenAllocation.toLocaleString(
+                        locale as string,
+                        {
+                          maximumFractionDigits: 2,
+                        }
+                      )}
+                      % {t("ofTokens")}
+                      {isCreator && (
+                        <span className="ml-1 text-green-400">
+                          (+{proposal.creatorAllocation}%{" "}
+                          {t("creatorAllocation")})
+                        </span>
+                      )}
+                    </p>
+                  </div>
+                </div>
+              );
+            })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/messages/en.json
+++ b/front/messages/en.json
@@ -173,7 +173,13 @@
     "supportSuccess": "Successfully supported the project",
     "supportError": "Failed to support the project",
     "minAmount": "Minimum amount is 0.001 SOL",
-    "alreadySupported": "You have already supported this proposal"
+    "alreadySupported": "You have already supported this proposal",
+    "supporters": "Supporters",
+    "noSupportersYet": "No supporters yet",
+    "errorLoadingSupports": "Error loading supporters",
+    "ofTokens": "of tokens",
+    "creatorWallet": "Creator's wallet",
+    "showingTop20": "showing top 20"
   },
   "EpochForm": {
     "title": "Create New Epoch",

--- a/front/messages/fr.json
+++ b/front/messages/fr.json
@@ -173,7 +173,13 @@
     "supportSuccess": "Projet soutenu avec succès",
     "supportError": "Échec du support du projet",
     "minAmount": "Le montant minimum est de 0.001 SOL",
-    "alreadySupported": "Vous avez déjà soutenu cette proposition"
+    "alreadySupported": "Vous avez déjà soutenu cette proposition",
+    "supporters": "Supporters",
+    "noSupportersYet": "Aucun supporter pour le moment",
+    "errorLoadingSupports": "Erreur lors du chargement des supporters",
+    "ofTokens": "des tokens",
+    "creatorWallet": "Portefeuille du créateur",
+    "showingTop20": "affichage du top 20"
   },
   "EpochForm": {
     "title": "Créer un Nouvel Epoch",


### PR DESCRIPTION
# feat(front): Affichage des Proposal Support liés à un token proposal

## Objectif

Afficher les contributions ("Proposal Support") associées à une proposition de token, afin d’améliorer la transparence et la compréhension du soutien communautaire.

## 📌 Description

- **Contexte** : Jusqu’à présent, aucun détail sur les "Proposal Support" n’était visible pour un token donné.
- **Problème résolu** : Les utilisateurs ne pouvaient pas consulter les contributions des supporters, ce qui nuisait à la transparence et à l’engagement.
- **Solution apportée** :
  * Ajout d’une section dédiée dans la page de détail d’un token proposal.
  * Affichage d’une liste des supports avec :
    - Nom ou identifiant du supporter
    - Montant de la contribution
    - Date de la contribution
    - Statut de la contribution (confirmée / en attente)
  * Utilisation d’un composant `ProposalSupportList.tsx` pour lister les supports.
  * Ajout d’un filtre par statut (ex. : "Tous", "Confirmés", "En attente").
  * Formatage clair pour mobile et desktop.

## ✅ Type de changement

- [ ] 🐛 Correction de bug
- [x] ✨ Nouvelle fonctionnalité
- [x] 🔧 Refactoring
- [ ] 📝 Mise à jour de la documentation
- [ ] 🚀 Amélioration des performances
- [ ] ✅ Ajout de tests
- [ ] 🔒 Amélioration de la sécurité
- [x] Autre : UX / UI

## 🔍 Comment tester cette PR ?

1. Aller sur la page de détail d’un token ayant des supports associés.
2. Vérifier que la section "Supporters" s’affiche correctement.
3. Contrôler que les informations sont bien formatées et filtrables.
4. Tester l’affichage mobile.

## 📎 Liens associés

- **Issue liée** : #44

## 👥 Revue

- **Relecteurs suggérés** : @pylejeune @AlexLakarm 
- **Domaines concernés** :
  - `front/app/[locale]/proposal/[id]/page.tsx`
  - `components/proposal/ProposalSupportList.tsx`
  - `front/context/ProgramContext.tsx`

## 🧪 Checklist

- [x] Affichage des supports fonctionnel
- [x] Filtrage par statut opérationnel
- [x] Responsive vérifié
- [x] Composants réutilisables et isolés
- [x] Chargement conditionnel en fonction de la présence de données
- [x] Identification du support du créateur visible 🌱

## 📸 Captures d’écran

<img width="467" alt="image" src="https://github.com/user-attachments/assets/f8a538d6-d481-478c-a4c6-a772f51536a9" />

## 🗒️ Notes complémentaires

- Possibilité d’ajouter des graphes ou stats dans une future PR.
- Prévoir une pagination si le nombre de supports devient trop élevé.
