### PR TITLE
121 feature treasury and roles

### DIFF
--- a/programs/programs/programs/src/constants.rs
+++ b/programs/programs/programs/src/constants.rs
@@ -2,3 +2,24 @@ use anchor_lang::prelude::*;
 
 #[constant]
 pub const SEED: &str = "anchor";
+
+// --- Frais ---
+// Frais de création de proposition en lamports (0.005 SOL)
+pub const PROPOSAL_CREATION_FEE_LAMPORTS: u64 = 5_000_000;
+
+// Frais de support en pourcentage (0.5%)
+// SUPPORT_FEE_PERCENTAGE_NUMERATOR / SUPPORT_FEE_PERCENTAGE_DENOMINATOR
+// Par exemple, 5 / 1000 = 0.005 (soit 0.5%)
+pub const SUPPORT_FEE_PERCENTAGE_NUMERATOR: u64 = 5;
+pub const SUPPORT_FEE_PERCENTAGE_DENOMINATOR: u64 = 1000;
+
+// --- Pourcentages de Distribution de la Trésorerie (sur une base de 100) ---
+// Doivent sommer à 100
+pub const TREASURY_DISTRIBUTION_MARKETING_PERCENT: u8 = 10; // 10%
+pub const TREASURY_DISTRIBUTION_TEAM_PERCENT: u8 = 40;       // 40%
+pub const TREASURY_DISTRIBUTION_OPERATIONS_PERCENT: u8 = 5;  // 5%
+pub const TREASURY_DISTRIBUTION_INVESTMENTS_PERCENT: u8 = 44; // 44%
+pub const TREASURY_DISTRIBUTION_CRANK_PERCENT: u8 = 1;       // 1%
+
+// Seed pour le PDA Treasury
+pub const TREASURY_SEED: &[u8] = b"treasury";

--- a/programs/programs/programs/src/error.rs
+++ b/programs/programs/programs/src/error.rs
@@ -84,5 +84,11 @@ pub enum ErrorCode {
 
     #[msg("Could not retrieve bump seed.")]
     CouldNotRetrieveBump,
+
+    #[msg("Ce rôle existe déjà pour ce wallet.")]
+    RoleAlreadyExists,
+
+    #[msg("The maximum number of roles has been reached.")]
+    RolesCapacityExceeded,
 }
 

--- a/programs/programs/programs/src/error.rs
+++ b/programs/programs/programs/src/error.rs
@@ -90,5 +90,8 @@ pub enum ErrorCode {
 
     #[msg("The maximum number of roles has been reached.")]
     RolesCapacityExceeded,
+
+    #[msg("A calculation resulted in an overflow.")]
+    CalculationOverflow,
 }
 

--- a/programs/programs/programs/src/error.rs
+++ b/programs/programs/programs/src/error.rs
@@ -93,5 +93,11 @@ pub enum ErrorCode {
 
     #[msg("A calculation resulted in an overflow.")]
     CalculationOverflow,
+
+    #[msg("The support amount is insufficient to cover fees.")]
+    AmountTooLowToCoverFees,
+
+    #[msg("The calculated fee amount cannot be zero.")]
+    FeeCannotBeZero,
 }
 

--- a/programs/programs/programs/src/instructions/create_token_proposal.rs
+++ b/programs/programs/programs/src/instructions/create_token_proposal.rs
@@ -1,6 +1,8 @@
 use anchor_lang::prelude::*;
 use crate::state::*;
 use crate::error::ErrorCode;
+use crate::constants::*;
+use crate::utils::{distribute_fees_to_treasury, FeeType};
 
 #[derive(Accounts)]
 #[instruction(
@@ -34,6 +36,13 @@ pub struct CreateTokenProposal<'info> {
     // #[account(constraint = epoch.status == EpochStatus::Active @ CustomError::EpochNotActive)]
     pub epoch: Account<'info, EpochManagement>,
 
+    #[account(
+        mut,
+        seeds = [TREASURY_SEED],
+        bump
+    )]
+    pub treasury: Account<'info, Treasury>,
+
     pub system_program: Program<'info, System>,
 }
 
@@ -56,20 +65,39 @@ pub fn handler(
     creator_allocation: u8,
     lockup_period: i64,
 ) -> Result<()> {
-    // Vérifier que l'allocation du créateur ne dépasse pas 10%
     require!(
         creator_allocation <= 10,
         ErrorCode::CreatorAllocationTooHigh
     );
-
-    // Vérifier que l'époque est active
     require!(
         ctx.accounts.epoch.status == EpochStatus::Active,
         ErrorCode::EpochNotActive
     );
 
+    // --- Gestion des Frais ---
+    let creator_account_info = ctx.accounts.creator.to_account_info();
+    let treasury_account_info = ctx.accounts.treasury.to_account_info();
+    let system_program_account_info = ctx.accounts.system_program.to_account_info();
 
-    // Initialiser la proposition
+    // 1. Transférer les frais de création de proposition au compte Treasury
+    let cpi_accounts_transfer = anchor_lang::system_program::Transfer {
+        from: creator_account_info.clone(),
+        to: treasury_account_info.clone(),
+    };
+    let cpi_context_transfer = anchor_lang::context::CpiContext::new(
+        system_program_account_info.clone(), 
+        cpi_accounts_transfer
+    );
+    anchor_lang::system_program::transfer(cpi_context_transfer, PROPOSAL_CREATION_FEE_LAMPORTS)?;
+
+    // 2. Distribuer les frais perçus en utilisant la fonction utilitaire
+    distribute_fees_to_treasury(
+        &mut ctx.accounts.treasury,
+        PROPOSAL_CREATION_FEE_LAMPORTS,
+        FeeType::ProposalCreation
+    )?;
+    
+    // --- Initialiser la proposition (logique existante) ---
     let proposal = &mut ctx.accounts.token_proposal;
     proposal.epoch_id = ctx.accounts.epoch.epoch_id;
     proposal.creator = ctx.accounts.creator.key();
@@ -79,7 +107,6 @@ pub fn handler(
     proposal.image_url = image_url;
     proposal.total_supply = total_supply;
     proposal.creator_allocation = creator_allocation;
-    // Calculer la part restante et l'allocation des supporters (arrondi supérieur)
     let remaining_allocation = 100u8.saturating_sub(creator_allocation);
     proposal.supporter_allocation = remaining_allocation.saturating_add(1) / 2;
     proposal.sol_raised = 0;

--- a/programs/programs/programs/src/instructions/initialize_treasury.rs
+++ b/programs/programs/programs/src/instructions/initialize_treasury.rs
@@ -1,0 +1,44 @@
+use anchor_lang::prelude::*;
+use crate::state::{Treasury, TreasurySubAccount};
+
+#[derive(Accounts)]
+pub struct InitializeTreasury<'info> {
+    #[account(
+        init,
+        payer = authority,
+        space = 8 + Treasury::INIT_SPACE, // 8 pour le discriminateur + espace de la structure
+        seeds = [b"treasury".as_ref()],
+        bump
+    )]
+    pub treasury: Account<'info, Treasury>,
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+pub fn initialize_treasury(ctx: Context<InitializeTreasury>, initial_authority: Pubkey) -> Result<()> {
+    let treasury = &mut ctx.accounts.treasury;
+    treasury.authority = initial_authority;
+    treasury.marketing = TreasurySubAccount {
+        sol_balance: 0,
+        last_withdrawal: 0,
+    };
+    treasury.team = TreasurySubAccount {
+        sol_balance: 0,
+        last_withdrawal: 0,
+    };
+    treasury.operations = TreasurySubAccount {
+        sol_balance: 0,
+        last_withdrawal: 0,
+    };
+    treasury.investments = TreasurySubAccount {
+        sol_balance: 0,
+        last_withdrawal: 0,
+    };
+    treasury.crank = TreasurySubAccount {
+        sol_balance: 0,
+        last_withdrawal: 0,
+    };
+    msg!("Treasury account initialized with authority: {}", initial_authority);
+    Ok(())
+} 

--- a/programs/programs/programs/src/instructions/manage_treasury_role.rs
+++ b/programs/programs/programs/src/instructions/manage_treasury_role.rs
@@ -1,12 +1,12 @@
 // Treasury role management instructions for the norug.fun protocol
-// This file provides Anchor instructions to add and remove roles (Admin, CategoryManager, Withdrawer)
+// This file provides Anchor instructions to add, remove, and update roles (Admin, CategoryManager, Withdrawer)
 // to specific addresses for treasury sub-accounts. Only the authority can manage roles.
 
 use anchor_lang::prelude::*;
 use crate::state::{TreasuryRoles, TreasuryRole, RoleType};
 use crate::error::ErrorCode;
 
-/// Accounts required to add a new treasury role.
+/// Only the authority (admin) of the TreasuryRoles account can call this instruction.
 #[derive(Accounts)]
 pub struct AddTreasuryRole<'info> {
     /// The TreasuryRoles account (must be mutable and owned by authority)
@@ -40,7 +40,7 @@ pub fn add_treasury_role(
     Ok(())
 }
 
-/// Accounts required to remove a treasury role.
+/// Only the authority (admin) of the TreasuryRoles account can call this instruction.
 #[derive(Accounts)]
 pub struct RemoveTreasuryRole<'info> {
     /// The TreasuryRoles account (must be mutable and owned by authority)
@@ -63,5 +63,34 @@ pub fn remove_treasury_role(
         treasury_roles.roles.len() < original_len,
         ErrorCode::CustomError // Could define a specific error if needed
     );
+    Ok(())
+}
+
+/// Only the authority (admin) of the TreasuryRoles account can call this instruction.
+#[derive(Accounts)]
+pub struct UpdateTreasuryRole<'info> {
+    /// The TreasuryRoles account (must be mutable and owned by authority)
+    #[account(mut, has_one = authority)]
+    pub treasury_roles: Account<'info, TreasuryRoles>,
+    /// The authority allowed to manage roles
+    pub authority: Signer<'info>,
+}
+
+/// Updates the withdrawal limit and/or period for a given role.
+pub fn update_treasury_role(
+    ctx: Context<UpdateTreasuryRole>,
+    role_type: RoleType,
+    pubkey: Pubkey,
+    withdrawal_limit: Option<u64>,
+    withdrawal_period: Option<i64>,
+) -> Result<()> {
+    let treasury_roles = &mut ctx.accounts.treasury_roles;
+    let role = treasury_roles
+        .roles
+        .iter_mut()
+        .find(|r| r.pubkey == pubkey && r.role_type == role_type)
+        .ok_or(ErrorCode::CustomError)?; // Could define a specific error if needed
+    role.withdrawal_limit = withdrawal_limit;
+    role.withdrawal_period = withdrawal_period;
     Ok(())
 } 

--- a/programs/programs/programs/src/instructions/manage_treasury_role.rs
+++ b/programs/programs/programs/src/instructions/manage_treasury_role.rs
@@ -1,0 +1,67 @@
+// Treasury role management instructions for the norug.fun protocol
+// This file provides Anchor instructions to add and remove roles (Admin, CategoryManager, Withdrawer)
+// to specific addresses for treasury sub-accounts. Only the authority can manage roles.
+
+use anchor_lang::prelude::*;
+use crate::state::{TreasuryRoles, TreasuryRole, RoleType};
+use crate::error::ErrorCode;
+
+/// Accounts required to add a new treasury role.
+#[derive(Accounts)]
+pub struct AddTreasuryRole<'info> {
+    /// The TreasuryRoles account (must be mutable and owned by authority)
+    #[account(mut, has_one = authority)]
+    pub treasury_roles: Account<'info, TreasuryRoles>,
+    /// The authority allowed to manage roles
+    pub authority: Signer<'info>,
+}
+
+/// Adds a new role to a given address for a treasury category.
+pub fn add_treasury_role(
+    ctx: Context<AddTreasuryRole>,
+    role_type: RoleType,
+    pubkey: Pubkey,
+    withdrawal_limit: Option<u64>,
+    withdrawal_period: Option<i64>,
+) -> Result<()> {
+    let treasury_roles = &mut ctx.accounts.treasury_roles;
+    // Prevent duplicate roles for the same address and type
+    require!(
+        !treasury_roles.roles.iter().any(|r| r.pubkey == pubkey && r.role_type == role_type),
+        ErrorCode::RoleAlreadyExists
+    );
+    let new_role = TreasuryRole {
+        role_type,
+        pubkey,
+        withdrawal_limit,
+        withdrawal_period,
+    };
+    treasury_roles.roles.push(new_role);
+    Ok(())
+}
+
+/// Accounts required to remove a treasury role.
+#[derive(Accounts)]
+pub struct RemoveTreasuryRole<'info> {
+    /// The TreasuryRoles account (must be mutable and owned by authority)
+    #[account(mut, has_one = authority)]
+    pub treasury_roles: Account<'info, TreasuryRoles>,
+    /// The authority allowed to manage roles
+    pub authority: Signer<'info>,
+}
+
+/// Removes a role from a given address for a treasury category.
+pub fn remove_treasury_role(
+    ctx: Context<RemoveTreasuryRole>,
+    role_type: RoleType,
+    pubkey: Pubkey,
+) -> Result<()> {
+    let treasury_roles = &mut ctx.accounts.treasury_roles;
+    let original_len = treasury_roles.roles.len();
+    treasury_roles.roles.retain(|r| !(r.pubkey == pubkey && r.role_type == role_type));
+    require!(
+        treasury_roles.roles.len() < original_len,
+        ErrorCode::CustomError // Could define a specific error if needed
+    );
+    Ok(())
+} 

--- a/programs/programs/programs/src/instructions/mod.rs
+++ b/programs/programs/programs/src/instructions/mod.rs
@@ -7,6 +7,7 @@ pub mod start_epoch;
 pub mod support_proposal;
 pub mod update_proposal_status;
 pub mod reclaim_support;
+pub mod manage_treasury_role;
 
 pub use create_token_proposal::*;
 pub use end_epoch::*;
@@ -17,3 +18,4 @@ pub use start_epoch::*;
 pub use support_proposal::*;
 pub use update_proposal_status::*;
 pub use reclaim_support::*;
+pub use manage_treasury_role::*;

--- a/programs/programs/programs/src/instructions/mod.rs
+++ b/programs/programs/programs/src/instructions/mod.rs
@@ -1,21 +1,27 @@
+// Instructions de gestion des rôles et administrateurs
+pub mod manage_treasury_role;
+pub use manage_treasury_role::*;
+
+// Autres instructions principales
 pub mod create_token_proposal;
 pub mod end_epoch;
 pub mod initialize;
 pub mod initialize_program_config;
+pub mod initialize_treasury;     // Notre nouvelle instruction
 pub mod mark_epoch_processed;
+pub mod reclaim_support;
 pub mod start_epoch;
 pub mod support_proposal;
 pub mod update_proposal_status;
-pub mod reclaim_support;
-pub mod manage_treasury_role;
+// NOTE: initialize_epoch, update_program_config n'existent pas en tant que fichiers séparés actuellement.
 
 pub use create_token_proposal::*;
 pub use end_epoch::*;
 pub use initialize::*;
 pub use initialize_program_config::*;
+pub use initialize_treasury::*;
 pub use mark_epoch_processed::*;
+pub use reclaim_support::*;
 pub use start_epoch::*;
 pub use support_proposal::*;
 pub use update_proposal_status::*;
-pub use reclaim_support::*;
-pub use manage_treasury_role::*;

--- a/programs/programs/programs/src/lib.rs
+++ b/programs/programs/programs/src/lib.rs
@@ -5,12 +5,14 @@ pub mod constants;
 pub mod error;
 pub mod instructions;
 pub mod state;
+pub mod utils;
 
 use anchor_lang::prelude::*;
 
 pub use constants::*;
 pub use instructions::*;
 pub use state::*;
+pub use utils::*;
 
 declare_id!("3HBzNutk8DrRfffCS74S55adJAjgY8NHrWXgRtABaSbF");
 

--- a/programs/programs/programs/src/lib.rs
+++ b/programs/programs/programs/src/lib.rs
@@ -24,7 +24,7 @@ pub mod programs {
         ctx: Context<InitializeProgramConfig>,
         admin_authority: Pubkey,
     ) -> Result<()> {
-        initialize_program_config::handler(ctx, admin_authority)
+        instructions::initialize_program_config::handler(ctx, admin_authority)
     }
 
     pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {
@@ -90,7 +90,11 @@ pub mod programs {
         ctx: Context<InitializeTreasuryRoles>,
         authorities: Vec<Pubkey>,
     ) -> Result<()> {
-        manage_treasury_role::initialize_treasury_roles(ctx, authorities)
+        instructions::manage_treasury_role::initialize_treasury_roles(ctx, authorities)
+    }
+
+    pub fn initialize_treasury(ctx: Context<InitializeTreasury>, initial_authority: Pubkey) -> Result<()> {
+        instructions::initialize_treasury::initialize_treasury(ctx, initial_authority)
     }
 
     pub fn add_admin(

--- a/programs/programs/programs/src/lib.rs
+++ b/programs/programs/programs/src/lib.rs
@@ -85,4 +85,53 @@ pub mod programs {
     ) -> Result<()> {
         reclaim_support::handler(ctx)
     }
+
+    pub fn initialize_treasury_roles(
+        ctx: Context<InitializeTreasuryRoles>,
+        authorities: Vec<Pubkey>,
+    ) -> Result<()> {
+        manage_treasury_role::initialize_treasury_roles(ctx, authorities)
+    }
+
+    pub fn add_admin(
+        ctx: Context<AddAdmin>,
+        new_admin: Pubkey,
+    ) -> Result<()> {
+        manage_treasury_role::add_admin(ctx, new_admin)
+    }
+
+    pub fn remove_admin(
+        ctx: Context<RemoveAdmin>,
+        admin_to_remove: Pubkey,
+    ) -> Result<()> {
+        manage_treasury_role::remove_admin(ctx, admin_to_remove)
+    }
+
+    pub fn add_treasury_role(
+        ctx: Context<AddTreasuryRole>,
+        role_type: RoleType,
+        pubkey: Pubkey,
+        withdrawal_limit: Option<u64>,
+        withdrawal_period: Option<i64>,
+    ) -> Result<()> {
+        manage_treasury_role::add_treasury_role(ctx, role_type, pubkey, withdrawal_limit, withdrawal_period)
+    }
+
+    pub fn remove_treasury_role(
+        ctx: Context<RemoveTreasuryRole>,
+        role_type: RoleType,
+        pubkey: Pubkey,
+    ) -> Result<()> {
+        manage_treasury_role::remove_treasury_role(ctx, role_type, pubkey)
+    }
+
+    pub fn update_treasury_role(
+        ctx: Context<UpdateTreasuryRole>,
+        role_type: RoleType,
+        pubkey: Pubkey,
+        withdrawal_limit: Option<u64>,
+        withdrawal_period: Option<i64>,
+    ) -> Result<()> {
+        manage_treasury_role::update_treasury_role(ctx, role_type, pubkey, withdrawal_limit, withdrawal_period)
+    }
 }

--- a/programs/programs/programs/src/state/mod.rs
+++ b/programs/programs/programs/src/state/mod.rs
@@ -55,11 +55,59 @@ pub struct UserProposalSupport {
     pub amount: u64,                  // SOL invested
 }
 
+// --- Catégories de la Trésorerie ---
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq, Eq, InitSpace, Debug)]
+pub enum TreasuryCategory {
+    Marketing,
+    Team,
+    Operations,
+    Investments,
+    Crank,
+}
+
+// --- Sous-compte de Trésorerie ---
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace, Debug)]
+pub struct TreasurySubAccount {
+    pub sol_balance: u64,           // SOL détenu dans ce sous-compte
+    pub last_withdrawal: i64,       // Timestamp du dernier retrait
+}
+
+// --- Nouvelle structure Treasury avec sous-comptes ---
 #[account]
 #[derive(InitSpace)]
 pub struct Treasury {
-    pub authority: Pubkey,     // Public key authorized to manage the treasury
-    pub platform_fees: u64,    // Total platform fees collected in lamports
+    pub authority: Pubkey,          // Public key autorisée à gérer la trésorerie globale
+    pub marketing: TreasurySubAccount,
+    pub team: TreasurySubAccount,
+    pub operations: TreasurySubAccount,
+    pub investments: TreasurySubAccount,
+    pub crank: TreasurySubAccount,
+}
+
+// --- Types de rôles pour la gestion ---
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq, Eq, InitSpace, Debug)]
+pub enum RoleType {
+    Admin,
+    CategoryManager(TreasuryCategory),
+    Withdrawer(TreasuryCategory),
+}
+
+// --- Structure d'un rôle ---
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace, Debug)]
+pub struct TreasuryRole {
+    pub role_type: RoleType,
+    pub pubkey: Pubkey,             // Détenteur du rôle
+    pub withdrawal_limit: Option<u64>, // Limite de retrait (optionnelle)
+    pub withdrawal_period: Option<i64>, // Période de retrait (optionnelle)
+}
+
+// --- Mapping des rôles ---
+#[account]
+#[derive(InitSpace)]
+pub struct TreasuryRoles {
+    pub authority: Pubkey,          // Admin des rôles
+    #[max_len(16)]
+    pub roles: Vec<TreasuryRole>,   // Liste des rôles attribués
 }
 
 // --- Nouveau compte de configuration globale ---

--- a/programs/programs/programs/src/state/mod.rs
+++ b/programs/programs/programs/src/state/mod.rs
@@ -105,7 +105,9 @@ pub struct TreasuryRole {
 #[account]
 #[derive(InitSpace)]
 pub struct TreasuryRoles {
-    pub authority: Pubkey,          // Admin des rôles
+    /// List of up to 3 admin authorities allowed to manage roles
+    #[max_len(3)]
+    pub authorities: Vec<Pubkey>,
     #[max_len(16)]
     pub roles: Vec<TreasuryRole>,   // Liste des rôles attribués
 }

--- a/programs/programs/programs/src/utils/fee_distribution.rs
+++ b/programs/programs/programs/src/utils/fee_distribution.rs
@@ -1,0 +1,85 @@
+use anchor_lang::prelude::*;
+use crate::state::Treasury;
+use crate::constants::*;
+use crate::error::ErrorCode;
+
+// Énumération pour spécifier le type de frais à distribuer
+pub enum FeeType {
+    ProposalCreation, // Frais fixes de création de proposition
+    ProposalSupport,  // Frais en pourcentage du support de proposition
+    PoolCreation,     // (Futur) Frais de création de pool
+}
+
+// Fonction utilitaire pour distribuer les frais dans la trésorerie
+pub fn distribute_fees_to_treasury(
+    treasury: &mut Account<Treasury>,
+    fee_amount: u64,
+    fee_type: FeeType,
+) -> Result<()> {
+    match fee_type {
+        FeeType::ProposalCreation => {
+            // Pour les frais de création de proposition (faibles), 100% vont aux opérations
+            treasury.operations.sol_balance = treasury.operations.sol_balance
+                .checked_add(fee_amount)
+                .ok_or(ErrorCode::CalculationOverflow)?;
+            msg!("Proposal creation fee ({} lamports) allocated 100% to Operations treasury.", fee_amount);
+        }
+        FeeType::ProposalSupport | FeeType::PoolCreation => {
+            // Pour les autres types de frais (potentiellement plus élevés), appliquer la distribution standard
+            let marketing_share = fee_amount
+                .checked_mul(TREASURY_DISTRIBUTION_MARKETING_PERCENT as u64)
+                .ok_or(ErrorCode::CalculationOverflow)?
+                .checked_div(100)
+                .ok_or(ErrorCode::CalculationOverflow)?;
+
+            let team_share = fee_amount
+                .checked_mul(TREASURY_DISTRIBUTION_TEAM_PERCENT as u64)
+                .ok_or(ErrorCode::CalculationOverflow)?
+                .checked_div(100)
+                .ok_or(ErrorCode::CalculationOverflow)?;
+
+            let operations_share = fee_amount
+                .checked_mul(TREASURY_DISTRIBUTION_OPERATIONS_PERCENT as u64)
+                .ok_or(ErrorCode::CalculationOverflow)?
+                .checked_div(100)
+                .ok_or(ErrorCode::CalculationOverflow)?;
+
+            let investments_share = fee_amount
+                .checked_mul(TREASURY_DISTRIBUTION_INVESTMENTS_PERCENT as u64)
+                .ok_or(ErrorCode::CalculationOverflow)?
+                .checked_div(100)
+                .ok_or(ErrorCode::CalculationOverflow)?;
+
+            // Le reste va au crank pour éviter les poussières de lamports
+            let mut crank_share = fee_amount;
+            crank_share = crank_share.saturating_sub(marketing_share);
+            crank_share = crank_share.saturating_sub(team_share);
+            crank_share = crank_share.saturating_sub(operations_share);
+            crank_share = crank_share.saturating_sub(investments_share);
+
+            treasury.marketing.sol_balance = treasury.marketing.sol_balance
+                .checked_add(marketing_share)
+                .ok_or(ErrorCode::CalculationOverflow)?;
+            
+            treasury.team.sol_balance = treasury.team.sol_balance
+                .checked_add(team_share)
+                .ok_or(ErrorCode::CalculationOverflow)?;
+
+            treasury.operations.sol_balance = treasury.operations.sol_balance
+                .checked_add(operations_share) // Ajoute la part standard des opérations
+                .ok_or(ErrorCode::CalculationOverflow)?;
+            
+            treasury.investments.sol_balance = treasury.investments.sol_balance
+                .checked_add(investments_share)
+                .ok_or(ErrorCode::CalculationOverflow)?;
+
+            treasury.crank.sol_balance = treasury.crank.sol_balance
+                .checked_add(crank_share)
+                .ok_or(ErrorCode::CalculationOverflow)?;
+
+            msg!("Fee ({} lamports) distributed to treasury: M:{} T:{} O:{} I:{} C:{}", 
+                 fee_amount, marketing_share, team_share, operations_share, investments_share, crank_share);
+        }
+    }
+    Ok(())
+} 

--- a/programs/programs/programs/src/utils/mod.rs
+++ b/programs/programs/programs/src/utils/mod.rs
@@ -1,0 +1,3 @@
+pub mod fee_distribution;
+
+pub use fee_distribution::*; 

--- a/programs/tests/treasury_roles.test.ts
+++ b/programs/tests/treasury_roles.test.ts
@@ -1,0 +1,326 @@
+import * as anchor from '@coral-xyz/anchor';
+import { Program } from '@coral-xyz/anchor';
+import { PublicKey, Keypair, SystemProgram } from '@solana/web3.js';
+import { assert, expect } from 'chai';
+import { Programs } from '../target/types/programs';
+import { AnchorError } from '@coral-xyz/anchor';
+
+describe('TreasuryRoles (multi-admin & roles management)', () => {
+  // Variables de test
+  let provider: anchor.AnchorProvider;
+  let program: Program<Programs>; // À typer si IDL générée
+  let admin1: Keypair;
+  let admin2: Keypair;
+  let admin3: Keypair;
+  let notAdmin: Keypair;
+  let withdrawer: Keypair;
+  let categoryManager: Keypair;
+  let treasuryRolesPda: PublicKey;
+  let treasuryRolesBump: number;
+
+  before(async () => {
+    provider = anchor.AnchorProvider.env();
+    anchor.setProvider(provider);
+    // program = anchor.workspace.NorugFun as Program<NorugFun>; // À adapter
+    program = anchor.workspace.Programs as Program<Programs>;
+    admin1 = Keypair.generate();
+    admin2 = Keypair.generate();
+    admin3 = Keypair.generate();
+    notAdmin = Keypair.generate();
+    withdrawer = Keypair.generate();
+    categoryManager = Keypair.generate();
+    // Trouver le PDA TreasuryRoles (adapter seeds)
+    [treasuryRolesPda, treasuryRolesBump] = await PublicKey.findProgramAddressSync([
+      Buffer.from('treasury_roles'),
+    ], program.programId);
+    // Airdrop pour tous les wallets utilisés
+    for (const kp of [admin1, admin2, admin3, notAdmin, withdrawer, categoryManager]) {
+      const sig = await provider.connection.requestAirdrop(kp.publicKey, 2 * anchor.web3.LAMPORTS_PER_SOL);
+      await provider.connection.confirmTransaction(sig, "confirmed");
+    }
+  });
+
+  it('should initialize the TreasuryRoles account with a single admin', async () => {
+    await program.methods
+      .initializeTreasuryRoles([admin1.publicKey])
+      .accounts({
+        treasuryRoles: treasuryRolesPda,
+        payer: admin1.publicKey,
+        systemProgram: SystemProgram.programId,
+      })
+      .signers([admin1])
+      .rpc();
+    const acc = await program.account.treasuryRoles.fetch(treasuryRolesPda);
+    expect(acc.authorities.length).to.equal(1);
+    expect(acc.authorities[0].toBase58()).to.equal(admin1.publicKey.toBase58());
+  });
+
+  it('should allow an admin to add a second admin (up to 3)', async () => {
+    await program.methods
+      .addAdmin(admin2.publicKey)
+      .accounts({
+        treasuryRoles: treasuryRolesPda,
+        authority: admin1.publicKey,
+      })
+      .signers([admin1])
+      .rpc();
+    const acc = await program.account.treasuryRoles.fetch(treasuryRolesPda);
+    expect(acc.authorities.map((a: PublicKey) => a.toBase58())).to.include(admin2.publicKey.toBase58());
+  });
+
+  it('should not allow adding the same admin twice', async () => {
+    try {
+      await program.methods
+        .addAdmin(admin2.publicKey)
+        .accounts({
+          treasuryRoles: treasuryRolesPda,
+          authority: admin1.publicKey,
+        })
+        .signers([admin1])
+        .rpc();
+      assert.fail('Should not allow duplicate admin');
+    } catch (e) {
+      expect(e.message).to.match(/RoleAlreadyExists|custom program error/);
+    }
+  });
+
+  it('should not allow more than 3 admins', async () => {
+    await program.methods
+      .addAdmin(admin3.publicKey)
+      .accounts({
+        treasuryRoles: treasuryRolesPda,
+        authority: admin1.publicKey,
+      })
+      .signers([admin1])
+      .rpc();
+    const fakeAdmin = Keypair.generate();
+    try {
+      await program.methods
+        .addAdmin(fakeAdmin.publicKey)
+        .accounts({
+          treasuryRoles: treasuryRolesPda,
+          authority: admin1.publicKey,
+        })
+        .signers([admin1])
+        .rpc();
+      assert.fail('Should not allow more than 3 admins');
+    } catch (e) {
+      expect(e.message).to.match(/CustomError|custom program error/);
+    }
+  });
+
+  it('should allow an admin to remove another admin (if at least 1 remains)', async () => {
+    await program.methods
+      .removeAdmin(admin2.publicKey)
+      .accounts({
+        treasuryRoles: treasuryRolesPda,
+        authority: admin1.publicKey,
+      })
+      .signers([admin1])
+      .rpc();
+    const acc = await program.account.treasuryRoles.fetch(treasuryRolesPda);
+    expect(acc.authorities.map((a: PublicKey) => a.toBase58())).to.not.include(admin2.publicKey.toBase58());
+    expect(acc.authorities.length).to.be.gte(1);
+  });
+
+  it('should not allow removing the last remaining admin', async () => {
+    // On retire admin3 pour n'avoir plus qu'admin1
+    await program.methods
+      .removeAdmin(admin3.publicKey)
+      .accounts({
+        treasuryRoles: treasuryRolesPda,
+        authority: admin1.publicKey,
+      })
+      .signers([admin1])
+      .rpc();
+    try {
+      await program.methods
+        .removeAdmin(admin1.publicKey)
+        .accounts({
+          treasuryRoles: treasuryRolesPda,
+          authority: admin1.publicKey,
+        })
+        .signers([admin1])
+        .rpc();
+      assert.fail('Should not allow removing last admin');
+    } catch (e) {
+      expect(e.message).to.match(/CustomError|custom program error/);
+    }
+  });
+
+  it('should fail if a non-admin tries to add or remove an admin', async () => {
+    try {
+      await program.methods
+        .addAdmin(notAdmin.publicKey)
+        .accounts({
+          treasuryRoles: treasuryRolesPda,
+          authority: notAdmin.publicKey,
+        })
+        .signers([notAdmin])
+        .rpc();
+      assert.fail('Non-admin should not add admin');
+    } catch (e) {
+      expect(e.message).to.match(/Unauthorized|custom program error/);
+    }
+    try {
+      await program.methods
+        .removeAdmin(admin1.publicKey)
+        .accounts({
+          treasuryRoles: treasuryRolesPda,
+          authority: notAdmin.publicKey,
+        })
+        .signers([notAdmin])
+        .rpc();
+      assert.fail('Non-admin should not remove admin');
+    } catch (e) {
+      expect(e.message).to.match(/Unauthorized|custom program error/);
+    }
+  });
+
+  it('should allow an admin to add a Withdrawer role for a category', async () => {
+    await program.methods
+      .addTreasuryRole({ withdrawer: [{ marketing: {} }] }, withdrawer.publicKey, new anchor.BN(1000), new anchor.BN(3600))
+      .accounts({
+        treasuryRoles: treasuryRolesPda,
+        authority: admin1.publicKey,
+      })
+      .signers([admin1])
+      .rpc();
+    const acc = await program.account.treasuryRoles.fetch(treasuryRolesPda);
+    expect(acc.roles.some((r: any) => r.pubkey.toBase58() === withdrawer.publicKey.toBase58())).to.be.true;
+  });
+
+  it('should allow an admin to add a CategoryManager role for a category', async () => {
+    await program.methods
+      .addTreasuryRole({ categoryManager: [{ team: {} }] }, categoryManager.publicKey, null, null)
+      .accounts({
+        treasuryRoles: treasuryRolesPda,
+        authority: admin1.publicKey,
+      })
+      .signers([admin1])
+      .rpc();
+    const acc = await program.account.treasuryRoles.fetch(treasuryRolesPda);
+    expect(acc.roles.some((r: any) => r.pubkey.toBase58() === categoryManager.publicKey.toBase58())).to.be.true;
+  });
+
+  it('should not allow adding the same role twice for the same address and category', async () => {
+    try {
+      await program.methods
+        .addTreasuryRole({ withdrawer: [{ marketing: {} }] }, withdrawer.publicKey, new anchor.BN(1000), new anchor.BN(3600))
+        .accounts({
+          treasuryRoles: treasuryRolesPda,
+          authority: admin1.publicKey,
+        })
+        .signers([admin1])
+        .rpc();
+      assert.fail('Should not allow duplicate role');
+    } catch (e) {
+      expect(e.message).to.match(/RoleAlreadyExists|custom program error/);
+    }
+  });
+
+  it('should fail if a non-admin tries to add a role', async () => {
+    try {
+      await program.methods
+        .addTreasuryRole({ withdrawer: [{ marketing: {} }] }, notAdmin.publicKey, new anchor.BN(1000), new anchor.BN(3600))
+        .accounts({
+          treasuryRoles: treasuryRolesPda,
+          authority: notAdmin.publicKey,
+        })
+        .signers([notAdmin])
+        .rpc();
+      assert.fail('Non-admin should not add role');
+    } catch (e) {
+      expect(e.message).to.match(/Unauthorized|custom program error/);
+    }
+  });
+
+  it('should allow an admin to remove an existing role', async () => {
+    await program.methods
+      .removeTreasuryRole({ withdrawer: [{ marketing: {} }] }, withdrawer.publicKey)
+      .accounts({
+        treasuryRoles: treasuryRolesPda,
+        authority: admin1.publicKey,
+      })
+      .signers([admin1])
+      .rpc();
+    const acc = await program.account.treasuryRoles.fetch(treasuryRolesPda);
+    expect(acc.roles.some((r: any) => r.pubkey.toBase58() === withdrawer.publicKey.toBase58())).to.be.false;
+  });
+
+  it('should not fail if trying to remove a non-existent role (idempotent)', async () => {
+    await program.methods
+      .removeTreasuryRole({ withdrawer: [{ marketing: {} }] }, withdrawer.publicKey)
+      .accounts({
+        treasuryRoles: treasuryRolesPda,
+        authority: admin1.publicKey,
+      })
+      .signers([admin1])
+      .rpc();
+    // Pas d'assertion, juste pas d'erreur
+  });
+
+  it('should fail if a non-admin tries to remove a role', async () => {
+    try {
+      await program.methods
+        .removeTreasuryRole({ categoryManager: [{ team: {} }] }, categoryManager.publicKey)
+        .accounts({
+          treasuryRoles: treasuryRolesPda,
+          authority: notAdmin.publicKey,
+        })
+        .signers([notAdmin])
+        .rpc();
+      assert.fail('Non-admin should not remove role');
+    } catch (e) {
+      expect(e.message).to.match(/Unauthorized|custom program error/);
+    }
+  });
+
+  it('should allow an admin to update withdrawal limit and period for an existing role', async () => {
+    await program.methods
+      .updateTreasuryRole({ categoryManager: [{ team: {} }] }, categoryManager.publicKey, new anchor.BN(5000), new anchor.BN(7200))
+      .accounts({
+        treasuryRoles: treasuryRolesPda,
+        authority: admin1.publicKey,
+      })
+      .signers([admin1])
+      .rpc();
+    const acc = await program.account.treasuryRoles.fetch(treasuryRolesPda);
+    const role = acc.roles.find((r: any) => r.pubkey.toBase58() === categoryManager.publicKey.toBase58());
+    expect(role.withdrawalLimit.toNumber()).to.equal(5000);
+    expect(role.withdrawalPeriod.toNumber()).to.equal(7200);
+  });
+
+  it('should fail if trying to update a non-existent role', async () => {
+    try {
+      await program.methods
+        .updateTreasuryRole({ withdrawer: [{ operations: {} }] }, withdrawer.publicKey, new anchor.BN(1234), new anchor.BN(5678))
+        .accounts({
+          treasuryRoles: treasuryRolesPda,
+          authority: admin1.publicKey,
+        })
+        .signers([admin1])
+        .rpc();
+      assert.fail('Should not update non-existent role');
+    } catch (e) {
+      expect(e.message).to.match(/CustomError|custom program error/);
+    }
+  });
+
+  it('should fail if a non-admin tries to update a role', async () => {
+    try {
+      await program.methods
+        .updateTreasuryRole({ categoryManager: [{ team: {} }] }, categoryManager.publicKey, new anchor.BN(1111), new anchor.BN(2222))
+        .accounts({
+          treasuryRoles: treasuryRolesPda,
+          authority: notAdmin.publicKey,
+        })
+        .signers([notAdmin])
+        .rpc();
+      assert.fail('Non-admin should not update role');
+    } catch (e) {
+      expect(e.message).to.match(/Unauthorized|custom program error/);
+    }
+  });
+
+}); 


### PR DESCRIPTION
# feat: 121 - Gestion des rôles et trésorerie Phase 1 (Initialisation & Frais)

La phase 2 comprend le withdraw from Treasury (Ticket créé dans le kanban)

## 📌 Description

**Contexte Général**: Cette Pull Request (PR) jette les bases fondamentales pour la gestion de la trésorie de norugdotfun. Elle se décompose en deux volets majeurs :

1.  L'implémentation d'un système robuste de gestion des rôles et des administrateurs.
2.  La mise en place de la Phase 1 de la trésorerie, incluant son initialisation et la collecte des frais sur les opérations clés.

Il était indispensable d'implémenter la gestion des rôles **avant** de développer les fonctionnalités de la trésorerie. En effet, les opérations sur la trésorerie (notamment les futurs retraits) nécessiteront un contrôle d'accès strict basé sur ces rôles pour garantir la sécurité et la bonne gouvernance des fonds.

---

### Partie 1: Gestion des Rôles et des Administrateurs (Déjà passée en review)

**Problème résolu**: Absence d'un mécanisme formel pour attribuer des permissions spécifiques (administrateur, gestionnaire de catégorie, retireur) pour les futures opérations de trésorerie.
**Solution apportée**:
*   Définition des structures de données `TreasuryRoles` (contenant les `authorities` et une liste de `roles`) et `TreasuryRole` (avec `role_type`, `pubkey`, `withdrawal_limit`, `withdrawal_period`) dans `state/mod.rs`.
*   Ajout de l'enum `RoleType` (Admin, CategoryManager, Withdrawer) et `TreasuryCategory` dans `state/mod.rs`.
*   Implémentation des instructions suivantes dans `instructions/manage_treasury_role.rs` et exposées dans `lib.rs`:
    *   `initialize_treasury_roles`: Initialise le compte `TreasuryRoles` avec une liste d'administrateurs.
    *   `add_admin`: Permet à un admin d'ajouter un nouvel admin (limite de 3).
    *   `remove_admin`: Permet à un admin de supprimer un autre admin (au moins 1 admin doit rester).
    *   `add_treasury_role`: Permet à un admin d'ajouter un rôle (limite de 5 rôles au total, configuré dans le programme Rust).
    *   `remove_treasury_role`: Permet à un admin de supprimer un rôle (opération idempotente).
    *   `update_treasury_role`: Permet à un admin de mettre à jour les limites et périodes de retrait d'un rôle.
*   Définition des erreurs correspondantes dans `error.rs` (`Unauthorized`, `RoleAlreadyExists`, `AdminsCapacityExceeded`, `RolesCapacityExceeded`, `CannotRemoveLastAdmin`).

---

### Partie 2: Trésorerie (Phase 1 - Initialisation et Collecte des Frais) (New)

**Problème résolu**: Absence d'une trésorerie centralisée pour collecter les frais générés par le protocole et absence de mécanisme de collecte de ces frais.
**Solution apportée**:
*   **Initialisation de la Trésorerie**:
    *   Création de l'instruction `initialize_treasury` (`instructions/initialize_treasury.rs`) pour initialiser le compte PDA `Treasury`.
    *   Ce compte `Treasury` (défini dans `state/mod.rs` avec `TreasurySubAccount`) stocke les soldes pour 5 sous-comptes (Marketing, Team, Operations, Investments, Crank) et une autorité globale.
*   **Constantes et Utilitaires pour les Frais**:
    *   Création de `constants.rs` pour définir :
        *   `PROPOSAL_CREATION_FEE_LAMPORTS` (frais de création de proposition).
        *   `SUPPORT_FEE_PERCENTAGE_NUMERATOR` et `SUPPORT_FEE_PERCENTAGE_DENOMINATOR` (pourcentage de frais sur le support).
        *   `TREASURY_DISTRIBUTION_..._PERCENT` (pourcentages de distribution pour chaque catégorie).
        *   `TREASURY_SEED` (seed du PDA de la trésorerie).
    *   Création du module utilitaire `utils/fee_distribution.rs` contenant :
        *   L'enum `FeeType` (`ProposalCreation`, `ProposalSupport`, `PoolCreation`).
        *   La fonction `distribute_fees_to_treasury` pour répartir les frais dans les sous-comptes de la trésorerie selon le `FeeType`.
*   **Intégration des Frais dans `create_token_proposal`**:
    *   L'instruction transfère `PROPOSAL_CREATION_FEE_LAMPORTS` du créateur vers le PDA `Treasury`.
    *   Appel à `distribute_fees_to_treasury` pour allouer 100% de ces frais au sous-compte "Operations".
*   **Intégration des Frais dans `support_proposal`**:
    *   Calcul des frais basés sur le `SUPPORT_FEE_PERCENTAGE` du montant du support.
    *   Transfert des frais calculés du supporter vers le PDA `Treasury`.
    *   Appel à `distribute_fees_to_treasury` pour répartir ces frais selon les pourcentages définis dans `constants.rs`.
    *   Transfert du montant net (support - frais) au `TokenProposal`.
*   **Gestion des Erreurs Spécifiques aux Frais**:
    *   Ajout des erreurs `CalculationOverflow`, `AmountTooLowToCoverFees`, et `FeeCannotBeZero` dans `error.rs`.

## ✅ Type de changement

Cochez les options pertinentes :

- [ ] 🐛 Correction de bug
- [x] ✨ Nouvelle fonctionnalité
- [ ] 🔧 Refactoring
- [ ] 📝 Mise à jour de la documentation
- [ ] 🚀 Amélioration des performances
- [x] ✅ Ajout de tests
- [x] 🔒 Amélioration de la sécurité (par la gestion des rôles et la centralisation des fonds)
- [ ] Autre (précisez) :

## 🧪 Tests ajoutés

Des tests unitaires et d'intégration approfondis ont été mis en œuvre :

*   **Pour la Gestion des Rôles (`treasury_roles.test.ts`)**:
    *   Initialisation correcte du compte `TreasuryRoles`.
    *   Gestion multi-administrateurs complète (ajout, suppression, limites, autorisations).
    *   Gestion des rôles de trésorerie (ajout, mise à jour, suppression, limites, non-duplication, autorisations).
    *   Vérification des échecs attendus pour les opérations non autorisées ou invalides.
*   **Pour la Trésorerie et la Collecte des Frais**:
    *   **Initialisation de la Trésorerie**:
        *   Vérification de l'initialisation idempotente du compte `Treasury` dans `proposal.test.ts` et `crank_simulation.test.ts`.
    *   **Frais sur `create_token_proposal` (`proposal.test.ts`)**:
        *   Vérification de la déduction correcte des frais du solde du créateur.
        *   Vérification de l'augmentation correcte du solde du PDA `Treasury`.
        *   Vérification de l'allocation de 100% des frais au sous-compte "Operations".
    *   **Frais sur `support_proposal` (`proposal.test.ts`)**:
        *   Calcul et déduction corrects des frais du montant du support.
        *   Transfert correct des frais au PDA `Treasury`.
        *   Distribution correcte des frais aux différents sous-comptes de la trésorerie selon les pourcentages.
        *   Transfert correct du montant net à la proposition.
        *   Mise à jour des compteurs de la proposition (`sol_raised`, `total_contributions`).
    *   **Impact sur `reclaim_support` (`reclaim.test.ts`)**:
        *   Mise à jour du setup pour inclure l'initialisation de la trésorerie et son utilisation lors de la création/support de propositions.
        *   Adaptation des assertions pour vérifier que l'utilisateur récupère le montant *net* (après déduction des frais de support initiaux) et non le montant brut.

## 🔍 Comment tester cette PR ?

Fournissez des instructions pour tester les modifications :

1.  Récupérer la branche : `git checkout 121-feature-treasury-and-roles`
2.  (Optionnel, si non à jour) : `git pull origin 121-feature-treasury-and-roles`
3.  Naviguer vers le répertoire du programme : `cd programs/programs`
4.  Compiler le programme : `anchor build`
5.  Lancer les tests : `anchor test`

**Résultats attendus**:
*   La compilation (`anchor build`) doit se terminer avec succès.
*   Tous les tests (`anchor test`) doivent passer.

## 📎 Liens associés

*   **Issues liées** : #121
*   **Documentation** : (sera abordée dans une tâche ultérieure si nécessaire)

## 👥 Revue

*   **Relecteurs suggérés** : @pylejeune @alexandre-bourdois
*   **Domaines concernés** :
    *   `programs/programs/src/state/mod.rs`
    *   `programs/programs/src/instructions/manage_treasury_role.rs`
    *   `programs/programs/src/instructions/initialize_treasury.rs`
    *   `programs/programs/src/instructions/create_token_proposal.rs`
    *   `programs/programs/src/instructions/support_proposal.rs`
    *   `programs/programs/src/constants.rs`
    *   `programs/programs/src/utils/fee_distribution.rs`
    *   `programs/programs/src/lib.rs`
    *   `programs/programs/src/error.rs`
    *   `programs/tests/treasury_roles.test.ts`
    *   `programs/tests/proposal.test.ts`
    *   `programs/tests/reclaim.test.ts`
    *   `programs/tests/crank_simulation.test.ts` (pour l'initialisation de la trésorerie)

## 🧪 Checklist

- [x] Le code compile sans erreur
- [x] Les tests unitaires passent
- [ ] La documentation est à jour (partiellement via les commentaires de code, documentation formelle si besoin ultérieurement)
- [x] Les dépendances sont à jour (pas de modification de dépendances dans cette PR)
- [x] La PR est prête pour la revue

## 📸 Captures d'écran (si applicable)

![image](https://github.com/user-attachments/assets/1e4e2e8c-2d11-4332-8638-3c03fe040ae6)


## 🗒️ Notes complémentaires
*   Une erreur de linter TypeScript persiste dans `programs/tests/treasury_roles.test.ts` concernant la clé `treasuryRoles` dans la section `accounts` de l'instruction `initializeTreasuryRoles`. Il s'agit d'une particularité connue avec la génération de types d'Anchor qui n'affecte pas l'exécution des tests. Tous les tests passent comme attendu.
*   La limite de rôles par compte `TreasuryRoles` est fixée à 5.
*   La limite d'administrateurs par compte `TreasuryRoles` est fixée à 3, un mutlisig sera à envisager (Ticket à créer)
*   Les frais de création de proposition sont actuellement alloués à 100% au sous-compte "Operations" car ils sont négligeables (0.005SOL) ce qui ne rend pas cohérent leur redistribution. Les frais de support de proposition sont distribués selon des pourcentages définis.
* Les frais pris à la création de la Pool relèvent de la Phase 2 du protocole norugdotfun et ne sont donc pas encore intégrés