### PR TITLE
feat: add wallet links and fix multiple proposal support

### DIFF
--- a/front/app/[locale]/proposal/[id]/page.tsx
+++ b/front/app/[locale]/proposal/[id]/page.tsx
@@ -12,6 +12,7 @@ import { useWallet } from "@solana/wallet-adapter-react";
 import { PublicKey } from "@solana/web3.js";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
+import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -346,9 +347,12 @@ export default function ProposalDetailPage() {
               </div>
               <div className="bg-gray-900/50 p-3 rounded-lg">
                 <p className="text-sm text-gray-400 mb-1">{t("creator")}</p>
-                <p className="font-mono break-all">
-                  {proposal.creator.toBase58()}
-                </p>
+                <Link
+                  href={`/${locale}/profile/${proposal.creator.toString()}`}
+                  className="font-mono break-all hover:underline hover:text-[#e6d3ba] transition-colors"
+                >
+                  {proposal.creator.toString()}
+                </Link>
               </div>
               <div className="bg-gray-900/50 p-3 rounded-lg">
                 <p className="text-sm text-gray-400 mb-1">

--- a/front/components/proposal/ProposalSupportList.tsx
+++ b/front/components/proposal/ProposalSupportList.tsx
@@ -1,6 +1,7 @@
 import { DetailedProposal } from "@/app/[locale]/proposal/[id]/page";
 import { ProposalSupport, useProgram } from "@/context/ProgramContext";
 import { useTranslations } from "next-intl";
+import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
 
@@ -80,10 +81,13 @@ export default function ProposalSupportList({
                     <span className="text-sm text-gray-500">#{index + 1}</span>
                     <div>
                       <div className="flex items-center gap-2">
-                        <p className="font-mono text-sm text-gray-400">
+                        <Link
+                          href={`/${locale}/profile/${support.user.toString()}`}
+                          className="font-mono text-sm text-gray-400 hover:underline hover:text-[#e6d3ba] transition-colors"
+                        >
                           {support.user.toBase58().slice(0, 4)}...
                           {support.user.toBase58().slice(-4)}
-                        </p>
+                        </Link>
                         {isCreator && (
                           <span
                             className="text-green-400 cursor-help"

--- a/front/context/ProgramContext.tsx
+++ b/front/context/ProgramContext.tsx
@@ -446,8 +446,6 @@ export function ProgramProvider({ children }: { children: React.ReactNode }) {
           await (
             program as Program<Programs>
           ).account.userProposalSupport.fetch(userSupportPDA);
-          // If we get here, account already exists
-          throw new Error("You have already supported this proposal");
         } catch (err: any) {
           // If account doesn't exist, continue
           if (!err.message.includes("Account does not exist")) {


### PR DESCRIPTION
## 🧭 Objectif

Améliorer l’expérience utilisateur en rendant les adresses de wallet interactives et en supprimant une erreur obsolète empêchant de soutenir plusieurs fois une proposition.

---

## 📌 Description

### ✔️ Ce qui change

- **Ajout de liens** de redirection vers le profil utilisateur (`/profile/[wallet-address]`) dans :
  - `ProposalSupportList.tsx`
  - `ProposalDetailPage.tsx`
- **Suppression de l’erreur bloquante** dans `ProgramContext.tsx` :
  ```ts
  throw new Error("You have already supported this proposal");
