### PR TITLE
130 chore add timestamp to create proposal

### DIFF
--- a/programs/programs/programs/src/instructions/create_token_proposal.rs
+++ b/programs/programs/programs/src/instructions/create_token_proposal.rs
@@ -112,6 +112,9 @@ pub fn handler(
     proposal.sol_raised = 0;
     proposal.total_contributions = 0;
     proposal.lockup_period = lockup_period;
+    // Obtenir le timestamp actuel
+    let clock = Clock::get()?;
+    proposal.creation_timestamp = clock.unix_timestamp;
     proposal.status = ProposalStatus::Active;
 
     Ok(())

--- a/programs/programs/programs/src/state/mod.rs
+++ b/programs/programs/programs/src/state/mod.rs
@@ -36,6 +36,7 @@ pub struct TokenProposal {
     pub sol_raised: u64,              // SOL raised via UserProposalSupport
     pub total_contributions: u64,     // Number of supporters
     pub lockup_period: i64,           // Lock-up period in seconds during which the creator cannot sell
+    pub creation_timestamp: i64,      // Timestamp of the proposal creation
     pub status: ProposalStatus,       // Enum indicating the proposal status
 }
 

--- a/programs/tests/proposal.test.ts
+++ b/programs/tests/proposal.test.ts
@@ -226,6 +226,11 @@ describe("Tests des propositions de tokens", () => {
     expect(proposal.solRaised.toString()).to.equal("0");
     expect(proposal.totalContributions.toString()).to.equal("0");
     expect(proposal.lockupPeriod.toString()).to.equal(lockupPeriod.toString());
+
+    // --- Vérification ajoutée pour creationTimestamp ---
+    expect(proposal.creationTimestamp).to.exist;
+    expect(proposal.creationTimestamp).to.be.instanceOf(anchor.BN);
+    expect(proposal.creationTimestamp.gtn(0)).to.be.true;
   });
 
   // --- Tests Granulaires pour support_proposal ---


### PR DESCRIPTION
# 📝 chore: 130 - Add creation timestamp to TokenProposal

## 📌 Description

- **Contexte** : Ajout d'un champ `creation_timestamp` à la structure `TokenProposal` pour permettre un tri plus fin des propositions côté front-end (par exemple, par date de création). Ceci est lié au ticket #130.
- **Problème résolu** : L'identifiant d'époque (`epoch_id`) n'était pas suffisant pour trier les propositions par date de création précise.
- **Solution apportée** :
    - Ajout du champ `creation_timestamp: i64` à la structure `TokenProposal` dans `programs/programs/programs/src/state/mod.rs`.
    - Modification de l'instruction `create_token_proposal` dans `programs/programs/programs/src/instructions/create_token_proposal.rs` pour récupérer le timestamp Unix actuel via `Clock::get()` et l'assigner au nouveau champ lors de l'initialisation de la proposition.

## ✅ Type de changement

Cochez les options pertinentes :

- [ ] 🐛 Correction de bug
- [x] ✨ Nouvelle fonctionnalité (côté contrat, pour habiliter le front)
- [ ] 🔧 Refactoring
- [ ] 📝 Mise à jour de la documentation
- [ ] 🚀 Amélioration des performances
- [ ] ✅ Ajout de tests
- [ ] 🔒 Amélioration de la sécurité
- [ ] Autre (précisez) :

## 🔍 Comment tester cette PR ?

1.  S'assurer que la compilation passe : `cd programs/programs && anchor build`.
2.  S'assurer que tous les tests passent : `cd programs/programs && anchor test`.
3.  (Pour le front-end) Vérifier que le nouveau champ `creationTimestamp` est accessible via l'IDL mis à jour et peut être utilisé pour le tri.

## 📎 Liens associés

- **Issues liées** : #130 

## 👥 Revue

- **Relecteurs suggérés** : @pylejeune @alexandre-bourdois 
- **Domaines concernés** : `programs/programs/programs/src/state/mod.rs`, `programs/programs/programs/src/instructions/create_token_proposal.rs`

## 🧪 Checklist

- [x] Le code compile sans erreur
- [x] Les tests unitaires passent
- [ ] La documentation est à jour (Non applicable pour ce changement mineur)
- [ ] Les dépendances sont à jour (Non applicable)
- [x] La PR est prête pour la revue

## 📸 Captures d'écran (si applicable)

![image](https://github.com/user-attachments/assets/570ec70d-3c2b-41a6-aa4c-8061a6cfcc45)

![image](https://github.com/user-attachments/assets/a4cfdd8d-eb82-413d-8b6d-759e99e1b6fc)


## 🗒️ Notes complémentaires

Ce changement modifie la structure du compte `TokenProposal`, ce qui nécessitera une mise à jour de l'IDL côté front-end pour accéder au nouveau champ. L'espace alloué par `#[derive(InitSpace)]` s'est adapté automatiquement.