### PR TITLE
feat(claim): add claim button to profile and proposal pages

### DIFF
--- a/front/app/[locale]/profile/[id]/page.tsx
+++ b/front/app/[locale]/profile/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import ProfileImage from "@/components/profile/ProfileImage";
 import BackButton from "@/components/ui/BackButton";
-import { useProgram } from "@/context/ProgramContext";
+import { ProposalState, useProgram } from "@/context/ProgramContext";
 import { ipfsToHttp } from "@/utils/ImageStorage";
 import { useWallet } from "@solana/wallet-adapter-react";
 import { LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
@@ -10,25 +10,37 @@ import { Copy } from "lucide-react";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import Link from "next/link";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 type SortOrder = "asc" | "desc";
 type SortBy = "date" | "name" | "amount";
 type ViewMode = "created_proposals" | "supported_tokens";
+type ProposalStatusType = {
+  active?: {};
+  validated?: {};
+  rejected?: {};
+};
 
 export default function ProfilePage() {
   const t = useTranslations("Profile");
   const { locale, id } = useParams();
   const { publicKey } = useWallet();
-  const { getUserProposals, getUserSupportedProposals } = useProgram();
+  const {
+    getUserProposals,
+    getUserSupportedProposals,
+    reclaimSupport, // Ajout de reclaimSupport
+  } = useProgram();
   const [viewMode, setViewMode] = useState<ViewMode>("created_proposals");
   const [sortBy, setSortBy] = useState<SortBy>("date");
   const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
   const [loading, setLoading] = useState(true);
   const [proposals, setProposals] = useState<any[]>([]);
   const [isCurrentUser, setIsCurrentUser] = useState(false);
+  const router = useRouter();
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 10;
 
   const userAddress = Array.isArray(id) ? id[0] : id;
 
@@ -91,6 +103,44 @@ export default function ProfilePage() {
       toast.error(t("copyFailed"));
     }
   };
+
+  const handleReclaimSupport = async (proposal: ProposalState) => {
+    if (!publicKey || !id) return;
+
+    try {
+      await reclaimSupport(proposal.publicKey, parseInt(proposal.epochId));
+      toast.success(t("claimSuccess"));
+
+      // Recharger les propositions
+      const userPubKey = new PublicKey(id);
+      const data = await getUserSupportedProposals(userPubKey);
+      setProposals(data);
+    } catch (error) {
+      console.error("Failed to reclaim support:", error);
+      toast.error(t("claimError"));
+    }
+  };
+
+  // Fonction helper pour obtenir le statut sous forme de chaîne
+  const getStatusString = (status: ProposalStatusType): string => {
+    if ("active" in status) return "active";
+    if ("validated" in status) return "validated";
+    if ("rejected" in status) return "rejected";
+    return "unknown";
+  };
+
+  const handleCardClick = (proposalId: string) => {
+    router.push(`/${locale}/proposal/${proposalId}`);
+  };
+
+  // Calcul pour la pagination
+  const paginatedProposals = useMemo(() => {
+    const start = (currentPage - 1) * itemsPerPage;
+    const end = start + itemsPerPage;
+    return sortedProposals.slice(start, end);
+  }, [sortedProposals, currentPage]);
+
+  const totalPages = Math.ceil(sortedProposals.length / itemsPerPage);
 
   if (!id) {
     return (
@@ -191,36 +241,67 @@ export default function ProfilePage() {
           </div>
         ) : (
           <div className="space-y-4">
-            {sortedProposals.map((proposal) => (
-              <Link
+            {paginatedProposals.map((proposal) => (
+              <div
                 key={proposal.publicKey.toString()}
-                href={`/${locale}/proposal/${proposal.publicKey.toString()}`}
-                className="block bg-gray-800/50 p-4 rounded-lg hover:bg-gray-800 transition-colors"
+                onClick={() => handleCardClick(proposal.publicKey.toString())}
+                className="block bg-gray-800/50 p-3 rounded-lg hover:bg-gray-800 
+                          transition-colors cursor-pointer overflow-hidden relative"
               >
-                <div className="flex items-center gap-4">
-                  <div className="w-16 h-16 bg-gray-700 rounded-lg overflow-hidden relative flex-shrink-0">
+                <div className="flex items-center gap-3">
+                  {/* Image */}
+                  <div className="w-16 h-16 flex-shrink-0 bg-gray-700 rounded-lg overflow-hidden relative">
                     {proposal.imageUrl ? (
                       <Image
                         src={ipfsToHttp(proposal.imageUrl)}
                         alt={proposal.tokenName}
                         fill
                         className="object-cover"
+                        sizes="64px"
                       />
                     ) : (
-                      <div className="w-full h-full flex items-center justify-center text-gray-500">
+                      <div className="w-full h-full flex items-center justify-center text-gray-500 text-sm">
                         {t("noImage")}
                       </div>
                     )}
                   </div>
+
+                  {/* Contenu principal */}
                   <div className="flex-1 min-w-0">
-                    <h3 className="text-lg font-medium mb-1">
+                    <h3 className="font-medium text-base truncate">
                       {proposal.tokenName}
                     </h3>
-                    <p className="text-sm text-gray-400 mb-2">
-                      ${proposal.tokenSymbol}
-                    </p>
+                    <div className="flex items-center gap-2 text-sm text-gray-400">
+                      <span>${proposal.tokenSymbol}</span>
+                      <span>•</span>
+                      <span>#{proposal.epochId}</span>
+                      <span>•</span>
+                      <span
+                        className={`
+                          ${
+                            getStatusString(proposal.status) === "active"
+                              ? "text-green-500"
+                              : ""
+                          }
+                          ${
+                            getStatusString(proposal.status) === "validated"
+                              ? "text-blue-500"
+                              : ""
+                          }
+                          ${
+                            getStatusString(proposal.status) === "rejected"
+                              ? "text-red-500"
+                              : ""
+                          }
+                        `}
+                      >
+                        {t(
+                          `proposalStatus.${getStatusString(proposal.status)}`
+                        )}
+                      </span>
+                    </div>
                     {viewMode === "supported_tokens" && (
-                      <p className="text-sm text-gray-500">
+                      <div className="text-sm text-gray-500 mt-1">
                         {(proposal.solRaised / LAMPORTS_PER_SOL).toLocaleString(
                           locale as string,
                           {
@@ -229,12 +310,80 @@ export default function ProfilePage() {
                           }
                         )}{" "}
                         SOL
-                      </p>
+                      </div>
                     )}
                   </div>
+
+                  {/* Bouton Claim à droite - ajout de la vérification isCurrentUser */}
+                  {viewMode === "supported_tokens" &&
+                    "rejected" in proposal.status &&
+                    isCurrentUser && (
+                      <div className="flex-shrink-0 flex items-center">
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            e.preventDefault();
+                            handleReclaimSupport(proposal);
+                          }}
+                          className="px-3 py-1.5 sm:px-5 sm:py-2.5 bg-red-900/50 hover:bg-red-900 
+                                    text-red-100 text-sm sm:text-base rounded-lg transition-colors 
+                                    font-medium hover:bg-opacity-80"
+                        >
+                          Claim
+                        </button>
+                      </div>
+                    )}
                 </div>
-              </Link>
+              </div>
             ))}
+
+            {/* Pagination controls */}
+            {sortedProposals.length > itemsPerPage && (
+              <div className="flex flex-col sm:flex-row items-center justify-between gap-4 mt-6 text-sm">
+                <div className="text-gray-400">
+                  {t("pagination.showing", {
+                    start: (currentPage - 1) * itemsPerPage + 1,
+                    end: Math.min(
+                      currentPage * itemsPerPage,
+                      sortedProposals.length
+                    ),
+                    total: sortedProposals.length,
+                  })}
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+                    disabled={currentPage === 1}
+                    className={`px-3 py-1.5 rounded-lg transition-colors ${
+                      currentPage === 1
+                        ? "bg-gray-800/50 text-gray-500 cursor-not-allowed"
+                        : "bg-gray-800 text-gray-300 hover:bg-gray-700"
+                    }`}
+                  >
+                    {t("pagination.previous")}
+                  </button>
+
+                  <span className="px-3 py-1.5 bg-gray-800/50 rounded-lg">
+                    {currentPage} / {totalPages}
+                  </span>
+
+                  <button
+                    onClick={() =>
+                      setCurrentPage((p) => Math.min(totalPages, p + 1))
+                    }
+                    disabled={currentPage === totalPages}
+                    className={`px-3 py-1.5 rounded-lg transition-colors ${
+                      currentPage === totalPages
+                        ? "bg-gray-800/50 text-gray-500 cursor-not-allowed"
+                        : "bg-gray-800 text-gray-300 hover:bg-gray-700"
+                    }`}
+                  >
+                    {t("pagination.next")}
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/front/app/[locale]/profile/[id]/page.tsx
+++ b/front/app/[locale]/profile/[id]/page.tsx
@@ -27,11 +27,8 @@ export default function ProfilePage() {
   const t = useTranslations("Profile");
   const { locale, id } = useParams();
   const { publicKey } = useWallet();
-  const {
-    getUserProposals,
-    getUserSupportedProposals,
-    reclaimSupport, // Ajout de reclaimSupport
-  } = useProgram();
+  const { getUserProposals, getUserSupportedProposals, reclaimSupport } =
+    useProgram();
   const [viewMode, setViewMode] = useState<ViewMode>("created_proposals");
   const [sortBy, setSortBy] = useState<SortBy>("date");
   const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
@@ -121,7 +118,6 @@ export default function ProfilePage() {
     }
   };
 
-  // Fonction helper pour obtenir le statut sous forme de chaîne
   const getStatusString = (status: ProposalStatusType): string => {
     if ("active" in status) return "active";
     if ("validated" in status) return "validated";
@@ -314,7 +310,7 @@ export default function ProfilePage() {
                     )}
                   </div>
 
-                  {/* Bouton Claim à droite - ajout de la vérification isCurrentUser */}
+                  {/* Bouton Claim */}
                   {viewMode === "supported_tokens" &&
                     "rejected" in proposal.status &&
                     isCurrentUser && (

--- a/front/app/[locale]/proposal/[id]/page.tsx
+++ b/front/app/[locale]/proposal/[id]/page.tsx
@@ -2,11 +2,7 @@
 
 import ProposalSupportList from "@/components/proposal/ProposalSupportList";
 import BackButton from "@/components/ui/BackButton";
-import {
-  ProposalStatus,
-  ProposalSupport,
-  useProgram,
-} from "@/context/ProgramContext";
+import { ProposalSupport, useProgram } from "@/context/ProgramContext";
 import { ipfsToHttp } from "@/utils/ImageStorage";
 import { useWallet } from "@solana/wallet-adapter-react";
 import { PublicKey } from "@solana/web3.js";
@@ -16,6 +12,12 @@ import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
+
+type ProposalStatusType = {
+  active?: {};
+  validated?: {};
+  rejected?: {};
+};
 
 export type DetailedProposal = {
   id: string;
@@ -29,10 +31,11 @@ export type DetailedProposal = {
   totalSupply: number;
   creatorAllocation: number;
   supporterAllocation: number;
-  status: ProposalStatus;
+  status: ProposalStatusType;
   totalContributions: number;
   lockupPeriod: number;
   publicKey: PublicKey;
+  supporters: PublicKey[];
 };
 
 export default function ProposalDetailPage() {
@@ -40,8 +43,12 @@ export default function ProposalDetailPage() {
   const t = useTranslations("ProposalDetail");
   const { locale, id } = useParams();
   const { publicKey } = useWallet();
-  const { getProposalDetails, supportProposal, getProposalSupports } =
-    useProgram();
+  const {
+    getProposalDetails,
+    supportProposal,
+    getProposalSupports,
+    reclaimSupport,
+  } = useProgram();
 
   // 2. States
   const [supportAmount, setSupportAmount] = useState<string>("");
@@ -50,6 +57,7 @@ export default function ProposalDetailPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [supports, setSupports] = useState<ProposalSupport[]>([]);
   const [isLoadingSupports, setIsLoadingSupports] = useState(true);
+  const [isCurrentUser, setIsCurrentUser] = useState(false);
 
   // 3. Callbacks
   const loadProposal = useCallback(async () => {
@@ -76,10 +84,11 @@ export default function ProposalDetailPage() {
         totalSupply: details.totalSupply,
         creatorAllocation: details.creatorAllocation,
         supporterAllocation: details.supporterAllocation,
-        status: details.status as ProposalStatus,
+        status: details.status as unknown as ProposalStatusType,
         totalContributions: details.totalContributions,
         lockupPeriod: details.lockupPeriod,
         publicKey: details.publicKey,
+        supporters: details.supporters,
       });
     } catch (error) {
       toast.error(t("errorLoadingProposal"));
@@ -127,6 +136,19 @@ export default function ProposalDetailPage() {
     [proposal, supportAmount, supportProposal, t, loadSupports]
   );
 
+  const handleReclaimSupport = async () => {
+    if (!publicKey || !proposal) return;
+
+    try {
+      await reclaimSupport(proposal.publicKey, parseInt(proposal.epoch_id));
+      toast.success(t("claimSuccess"));
+      await loadProposal();
+    } catch (error) {
+      console.error("Failed to reclaim support:", error);
+      toast.error(t("claimError"));
+    }
+  };
+
   // 4. Effects
   useEffect(() => {
     loadProposal();
@@ -138,6 +160,11 @@ export default function ProposalDetailPage() {
     }
   }, [proposal, loadSupports]);
 
+  useEffect(() => {
+    if (!publicKey) return;
+    setIsCurrentUser(publicKey.toBase58() === id);
+  }, [publicKey, id]);
+
   // 5. Render helpers
   const formatNumber = useCallback(
     (number: number) => {
@@ -147,25 +174,22 @@ export default function ProposalDetailPage() {
   );
 
   // Helper function to get status string
-  const getStatusString = (status: any): ProposalStatus => {
-    if (typeof status === "object") {
-      // If status is an object, take the first key
-      return Object.keys(status)[0] as ProposalStatus;
-    }
-    return status as ProposalStatus;
+  const getStatusString = (status: any): string => {
+    if ("active" in status) return "active";
+    if ("validated" in status) return "validated";
+    if ("rejected" in status) return "rejected";
+    return "unknown";
   };
 
   // Helper function to get status color
-  const getStatusColor = (status: ProposalStatus) => {
-    switch (status) {
-      case "active":
-        return "bg-blue-500 text-white";
-      case "validated":
-        return "bg-green-500 text-white";
-      case "rejected":
-        return "bg-red-500 text-white";
-    }
+  const getStatusColor = (status: ProposalStatusType) => {
+    if ("active" in status) return "bg-blue-500 text-white";
+    if ("validated" in status) return "bg-green-500 text-white";
+    if ("rejected" in status) return "bg-red-500 text-white";
+    return "bg-gray-500 text-white";
   };
+
+  const isFullyLoaded = !loading && !isLoadingSupports && proposal && supports;
 
   // Loading state
   if (loading) {
@@ -230,77 +254,102 @@ export default function ProposalDetailPage() {
 
             {/* Stats Section */}
             <div className="flex flex-col items-center lg:items-start gap-2 mb-6">
-              <p className="text-xl font-medium text-green-500">
-                {t("solanaRaised", {
-                  amount: proposal.solRaised.toLocaleString(locale, {
-                    minimumFractionDigits: 2,
-                    maximumFractionDigits: 2,
-                  }),
-                })}
-              </p>
-              <p
-                className={`text-base font-medium ${
-                  getStatusString(proposal.status) === "validated"
-                    ? "text-green-500"
-                    : getStatusString(proposal.status) === "active"
-                    ? "text-blue-500"
-                    : "text-red-500"
-                }`}
-              >
-                {t(`status.${getStatusString(proposal.status)}`)}
-              </p>
-
-              {/* Support Form */}
-              {publicKey ? (
-                getStatusString(proposal.status) !== "active" ? (
-                  <p className="text-sm text-gray-400">
-                    {t("proposalNotActive")}
+              {isFullyLoaded ? (
+                <>
+                  <p className="text-xl font-medium text-green-500">
+                    {t("solanaRaised", {
+                      amount: proposal.solRaised.toLocaleString(locale, {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2,
+                      }),
+                    })}
                   </p>
-                ) : (
-                  <div className="w-full max-w-sm mt-4">
-                    <form
-                      onSubmit={handleSupport}
-                      className="flex flex-col gap-3"
-                    >
-                      <div className="relative">
-                        <input
-                          type="number"
-                          value={supportAmount}
-                          onChange={(e) => setSupportAmount(e.target.value)}
-                          min="0.001"
-                          step="0.001"
-                          required
-                          placeholder="0.0"
-                          className="w-full bg-gray-800/50 border border-gray-700 rounded-lg px-4 py-2 pr-12 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
-                        />
-                        <span className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400">
-                          SOL
-                        </span>
+                  <p
+                    className={`text-base font-medium ${
+                      getStatusString(proposal.status) === "validated"
+                        ? "text-green-500"
+                        : getStatusString(proposal.status) === "active"
+                        ? "text-blue-500"
+                        : "text-red-500"
+                    }`}
+                  >
+                    {t(`status.${getStatusString(proposal.status)}`)}
+                  </p>
+
+                  {/* Support Form */}
+                  {publicKey ? (
+                    "active" in proposal.status ? (
+                      <div className="w-full max-w-sm mt-4">
+                        <form
+                          onSubmit={handleSupport}
+                          className="flex flex-col gap-3"
+                        >
+                          <div className="relative">
+                            <input
+                              type="number"
+                              value={supportAmount}
+                              onChange={(e) => setSupportAmount(e.target.value)}
+                              min="0.001"
+                              step="0.001"
+                              required
+                              placeholder="0.0"
+                              className="w-full bg-gray-800/50 border border-gray-700 rounded-lg px-4 py-2 pr-12 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            />
+                            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400">
+                              SOL
+                            </span>
+                          </div>
+                          <p className="text-xs text-gray-400">
+                            {t("minAmount")}
+                          </p>
+                          <button
+                            type="submit"
+                            disabled={
+                              isSubmitting ||
+                              !supportAmount ||
+                              parseFloat(supportAmount) < 0.001
+                            }
+                            className="w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                          >
+                            {isSubmitting ? t("supporting") : t("support")}
+                          </button>
+                        </form>
                       </div>
-                      <p className="text-xs text-gray-400">{t("minAmount")}</p>
+                    ) : (
+                      "rejected" in proposal.status &&
+                      supports.some(
+                        (support) =>
+                          support.user.toBase58() === publicKey.toBase58() &&
+                          support.amount > 0 // On vérifie juste si l'utilisateur a supporté
+                      ) && (
+                        <button
+                          onClick={handleReclaimSupport}
+                          disabled={loading}
+                          className="w-full px-6 py-3 rounded-lg font-medium 
+                                  bg-red-900/50 hover:bg-red-900 text-red-100 
+                                  transition-colors hover:bg-opacity-80"
+                        >
+                          {t("claimButton")}
+                        </button>
+                      )
+                    )
+                  ) : (
+                    "active" in proposal.status && (
                       <button
-                        type="submit"
-                        disabled={
-                          isSubmitting ||
-                          !supportAmount ||
-                          parseFloat(supportAmount) < 0.001
-                        }
-                        className="w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        onClick={() => {
+                          /* add wallet connect action */
+                        }}
+                        className="mt-4 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-6 rounded-lg transition-colors"
                       >
-                        {isSubmitting ? t("supporting") : t("support")}
+                        {t("connectToSupport")}
                       </button>
-                    </form>
-                  </div>
-                )
+                    )
+                  )}
+                </>
               ) : (
-                <button
-                  onClick={() => {
-                    /* add wallet connect action */
-                  }}
-                  className="mt-4 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-6 rounded-lg transition-colors"
-                >
-                  {t("connectToSupport")}
-                </button>
+                <div className="w-full flex justify-center py-4">
+                  <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white" />
+                </div>
               )}
             </div>
           </div>

--- a/front/app/[locale]/proposal/[id]/page.tsx
+++ b/front/app/[locale]/proposal/[id]/page.tsx
@@ -320,7 +320,7 @@ export default function ProposalDetailPage() {
                       supports.some(
                         (support) =>
                           support.user.toBase58() === publicKey.toBase58() &&
-                          support.amount > 0 // On vérifie juste si l'utilisateur a supporté
+                          support.amount > 0
                       ) && (
                         <button
                           onClick={handleReclaimSupport}
@@ -336,9 +336,7 @@ export default function ProposalDetailPage() {
                   ) : (
                     "active" in proposal.status && (
                       <button
-                        onClick={() => {
-                          /* add wallet connect action */
-                        }}
+                        onClick={() => {}}
                         className="mt-4 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-6 rounded-lg transition-colors"
                       >
                         {t("connectToSupport")}

--- a/front/messages/en.json
+++ b/front/messages/en.json
@@ -180,7 +180,11 @@
     "errorLoadingSupports": "Error loading supporters",
     "ofTokens": "of tokens",
     "creatorWallet": "Creator's wallet",
-    "showingTop20": "showing top 20"
+    "showingTop20": "showing top 20",
+    "proposalNotActive": "This proposal is no longer active",
+    "claimButton": "Claim",
+    "claimSuccess": "Funds claimed successfully!",
+    "claimError": "Error claiming funds"
   },
   "EpochForm": {
     "title": "Create New Epoch",
@@ -363,6 +367,25 @@
     "invalidAddress": "Invalid address",
     "errorLoadingProposals": "Error loading proposals",
     "addressCopied": "Address copied to clipboard",
-    "copyFailed": "Failed to copy address"
+    "copyFailed": "Failed to copy address",
+    "epochId": "Epoch",
+    "proposalStatus": {
+      "active": "Active",
+      "validated": "Validated",
+      "rejected": "Rejected"
+    },
+    "claimButton": "Claim",
+    "claimSuccess": "Funds claimed successfully!",
+    "claimError": "Error claiming funds",
+    "pagination": {
+      "previous": "Previous",
+      "next": "Next",
+      "showing": "Showing {start} to {end} of {total} tokens"
+    }
+  },
+  "Proposal": {
+    "claimButton": "Claim",
+    "claimSuccess": "Funds claimed successfully!",
+    "claimError": "Error claiming funds"
   }
 }

--- a/front/messages/fr.json
+++ b/front/messages/fr.json
@@ -180,7 +180,11 @@
     "errorLoadingSupports": "Erreur lors du chargement des supporters",
     "ofTokens": "des tokens",
     "creatorWallet": "Portefeuille du créateur",
-    "showingTop20": "affichage du top 20"
+    "showingTop20": "affichage du top 20",
+    "proposalNotActive": "Cette proposition n'est plus active",
+    "claimButton": "Récupérer",
+    "claimSuccess": "Fonds récupérés avec succès !",
+    "claimError": "Erreur lors de la récupération des fonds"
   },
   "EpochForm": {
     "title": "Créer un Nouvel Epoch",
@@ -360,6 +364,25 @@
     "invalidAddress": "Adresse invalide",
     "errorLoadingProposals": "Erreur lors du chargement des propositions",
     "addressCopied": "Adresse copiée dans le presse-papiers",
-    "copyFailed": "Échec de la copie de l'adresse"
+    "copyFailed": "Échec de la copie de l'adresse",
+    "epochId": "Epoch",
+    "proposalStatus": {
+      "active": "Active",
+      "validated": "Validée",
+      "rejected": "Rejetée"
+    },
+    "claimButton": "Récupérer",
+    "claimSuccess": "Fonds récupérés avec succès !",
+    "claimError": "Erreur lors de la récupération des fonds",
+    "pagination": {
+      "previous": "Précédent",
+      "next": "Suivant",
+      "showing": "Affichage de {start} à {end} sur {total} tokens"
+    }
+  },
+  "Proposal": {
+    "claimButton": "Récupérer",
+    "claimSuccess": "Fonds récupérés avec succès !",
+    "claimError": "Erreur lors de la récupération des fonds"
   }
 }


### PR DESCRIPTION
# feat(front): Ajout du bouton "Claim" pour récupérer les SOL mis en jeu

## Objectif

Permettre aux utilisateurs de réclamer les SOL qu’ils ont mis en jeu lors d’une proposition de token, une fois l’époque correspondante clôturée.

## 📌 Description

- **Contexte** : Actuellement, après la clôture d’une époque, les utilisateurs ne peuvent pas récupérer les SOL engagés dans une proposition de token.
- **Problème résolu** : Cette absence crée de la confusion et nuit à l’expérience utilisateur.
- **Solution apportée** :
  * Ajout d’un bouton **"Claim"** sur la page de profil , à côté de chaque proposition de token et sur la page DetailProposal.
  * Le bouton s’affiche uniquement si :
    - l’époque est clôturée
    - les SOL n’ont pas encore été réclamés
  * Lors du clic :
    - Une action de réclamation est déclenchée (backend ou smart contract).
    - Un retour utilisateur est affiché (notification de succès, désactivation du bouton, etc.).
  * Le bouton est masqué ou désactivé si non applicable.

## ✅ Type de changement

- [ ] 🐛 Correction de bug  
- [x] ✨ Nouvelle fonctionnalité  
- [x] 🔧 Refactoring  
- [ ] 📝 Mise à jour de la documentation  
- [ ] 🚀 Amélioration des performances  
- [ ] ✅ Ajout de tests  
- [ ] 🔒 Amélioration de la sécurité  
- [x] Autre : UX / UI  

## 🔍 Comment tester cette PR ?

1. Aller sur la page de profil d’un utilisateur ayant participé à une proposition dont l’époque est clôturée.
2. Vérifier que le bouton "Claim" s’affiche correctement.
3. Cliquer sur le bouton :
   - Vérifier que les SOL sont réclamés avec succès.
   - Un message de confirmation est affiché.
   - Le bouton disparaît ou devient inactif.
4. Tester les cas où l’époque est encore active ou les SOL déjà réclamés.

## 📎 Liens associés

- **Issue liée** : [#46 – Ajout bouton Claim](https://github.com/pylejeune/norug-fun/issues/46)
- **Parent** : Feature reclaim_support pour les proposals rejected

## 👥 Revue

- **Relecteurs suggérés** : @pylejeune @AlexLakarm  
- **Domaines concernés** :
  - `front/app/profile/[id]/page.tsx`
  - `front/app/proposal/[id]/page.tsx`


## 🧪 Checklist

- [x] Affichage conditionnel du bouton Claim
- [x] Fonction de réclamation opérationnelle
- [x] Message utilisateur clair
- [x] Responsive vérifié
- [x] Cas d’erreurs bien gérés
- [x] Statut post-réclamation correctement mis à jour

## 📸 Captures d’écran

<img width="636" alt="image" src="https://github.com/user-attachments/assets/be4f57e9-6a5e-4d97-84dc-e9aaf8e6a193" />