### PR TITLE
feat: add notifier request reviwers in discord

### DIFF
--- a/.github/workflows/notify-reviewers-discord.yml
+++ b/.github/workflows/notify-reviewers-discord.yml
@@ -1,0 +1,18 @@
+name: Notify Discord on Review Request
+
+on:
+  pull_request:
+    types: [review_requested]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send notification to Discord
+        env:
+          DISCORD_WEBHOOK_URL_REVIEWER: ${{ secrets.DISCORD_WEBHOOK_URL_REVIEWER }}
+        run: |
+          curl -H "Content-Type: application/json" \
+               -X POST \
+               -d "{\"content\": \"👀 Revue demandée par ${{ github.actor }} à ${{ github.event.requested_reviewer.login || github.event.requested_team.name }} pour la PR : ${{ github.event.pull_request.html_url }}\"}" \
+               $DISCORD_WEBHOOK_URL_REVIEWER 


### PR DESCRIPTION

# 📝 Ajout d'un workflow de notification Discord pour les demandes de revue

## 📌 Description

- **Contexte** : Amélioration de notre système de notifications pour accélérer le processus de revue de code.
- **Problème résolu** : Manque de visibilité immédiate lorsqu'un développeur est sollicité pour une revue de code.
- **Solution apportée** : Création d'un workflow GitHub Actions qui notifie automatiquement sur Discord lorsqu'une revue est demandée.

## ✅ Type de changement

- [ ] 🐛 Correction de bug
- [x] ✨ Nouvelle fonctionnalité
- [ ] 🔧 Refactoring
- [ ] 📝 Mise à jour de la documentation
- [ ] 🚀 Amélioration des performances
- [ ] ✅ Ajout de tests
- [ ] 🔒 Amélioration de la sécurité
- [ ] Autre (précisez) :

## 🔍 Comment tester cette PR ?

1. Créez une pull request et demandez une revue à un membre de l'équipe
2. Vérifiez que la notification apparaît sur le canal Discord approprié
3. Vérifiez que le message contient le nom du demandeur, du reviewer et le lien vers la PR

## 📎 Liens associés

- **Issues liées** : #150 
- **Documentation** : [Documentation GitHub Actions](https://docs.github.com/fr/actions)
- **Autres PRs** : N/A

## 👥 Revue

- **Relecteurs suggérés** : @DevOpsLead
- **Domaines concernés** : GitHub Actions, Intégration Discord

## 🧪 Checklist

- [x] Le code compile sans erreur
- [x] Les tests unitaires passent
- [x] La documentation est à jour
- [x] Les dépendances sont à jour
- [x] La PR est prête pour la revue

## 📸 Captures d'écran

![Exemple de notification Discord](https://exemple.com/screenshot-discord-notification.png)

## 🗒️ Notes complémentaires

Modifications principales apportées:
- Création du fichier `.github/workflows/notify-reviewers-discord.yml`
- Configuration du déclencheur sur l'événement `review_requested`
- Mise en place d'une requête curl vers le webhook Discord
- Formatage du message pour inclure les informations essentielles (demandeur, reviewer, lien)
- Utilisation d'un secret dédié `DISCORD_WEBHOOK_URL_REVIEWER` pour séparer cette notification des autres

Le secret `DISCORD_WEBHOOK_URL_REVIEWER` a été ajouté dans les paramètres du dépôt GitHub. Assurez-vous qu'il pointe vers le canal Discord approprié.
