### PR TITLE
[Feature] Tri par timestamp des proposals + Ajout d'un .env pour le front

### DIFF
--- a/front/.env.example
+++ b/front/.env.example
@@ -1,0 +1,15 @@
+# Choix du réseau (localhost ou devnet)
+NEXT_PUBLIC_SOLANA_NETWORK=localhost
+
+#API KEY de lighthouse pour la gestion des images en IPFS
+#https://lighthouse.storage/
+NEXT_PUBLIC_LIGHTHOUSE_KEY=abcdefgh.12345678901234567890123456789012
+
+#Token d'authentification pour l'API
+API_SECRET_KEY=
+
+#Clé privée encodée en base64 pour le wallet admin
+ADMIN_SEED_BASE64=
+
+#URL du nœud RPC Solana
+SOLANA_RPC_ENDPOINT=

--- a/front/.gitignore
+++ b/front/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/front/app/[locale]/proposal/[id]/page.tsx
+++ b/front/app/[locale]/proposal/[id]/page.tsx
@@ -6,6 +6,8 @@ import { ProposalSupport, useProgram } from "@/context/ProgramContext";
 import { ipfsToHttp } from "@/utils/ImageStorage";
 import { useWallet } from "@solana/wallet-adapter-react";
 import { PublicKey } from "@solana/web3.js";
+import { format } from "date-fns";
+import { enUS, fr } from "date-fns/locale";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import Link from "next/link";
@@ -36,6 +38,7 @@ export type DetailedProposal = {
   lockupPeriod: number;
   publicKey: PublicKey;
   supporters: PublicKey[];
+  creationTimestamp: number;
 };
 
 export default function ProposalDetailPage() {
@@ -89,6 +92,7 @@ export default function ProposalDetailPage() {
         lockupPeriod: details.lockupPeriod,
         publicKey: details.publicKey,
         supporters: details.supporters,
+        creationTimestamp: details.creationTimestamp,
       });
     } catch (error) {
       toast.error(t("errorLoadingProposal"));
@@ -173,7 +177,35 @@ export default function ProposalDetailPage() {
     [locale]
   );
 
-  // Helper function to get status string
+  // Format full date with validation
+  const formatFullDate = (timestamp: number, locale: string) => {
+    try {
+      // Validation plus stricte
+      if (!timestamp || typeof timestamp !== "number") {
+        console.warn("Invalid timestamp:", timestamp);
+        return "-";
+      }
+
+      const date = new Date(timestamp * 1000);
+
+      // Validation de la date
+      if (isNaN(date.getTime())) {
+        console.warn("Invalid date from timestamp:", timestamp);
+        return "-";
+      }
+
+      return format(
+        date,
+        locale === "fr" ? "d MMMM yyyy 'à' HH:mm" : "MMMM d, yyyy 'at' HH:mm",
+        { locale: locale === "fr" ? fr : enUS }
+      );
+    } catch (error) {
+      console.error("Error formatting date:", error);
+      return "-";
+    }
+  };
+
+  // Get proposal status string
   const getStatusString = (status: any): string => {
     if ("active" in status) return "active";
     if ("validated" in status) return "validated";
@@ -388,6 +420,14 @@ export default function ProposalDetailPage() {
           <div className="bg-gray-800/50 p-4 rounded-lg">
             <h2 className="text-lg font-medium mb-4">{t("details")}</h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="bg-gray-900/50 p-3 rounded-lg">
+                <p className="text-sm text-gray-400 mb-1">
+                  {t("creationDate")}
+                </p>
+                <p>
+                  {formatFullDate(proposal.creationTimestamp, locale as string)}
+                </p>
+              </div>
               <div className="bg-gray-900/50 p-3 rounded-lg">
                 <p className="text-sm text-gray-400 mb-1">{t("epochId")}</p>
                 <p>{proposal.epoch_id}</p>

--- a/front/components/home/ActiveProposalsView.tsx
+++ b/front/components/home/ActiveProposalsView.tsx
@@ -1,11 +1,10 @@
 import EpochSelector from "@/components/epoch/EpochSelector";
 import { ProposalCard } from "@/components/home/ProposalCard";
 import { EpochState, ProposalState } from "@/context/ProgramContext";
-import { cn } from "@/lib/utils";
 import { format } from "date-fns";
 import { enUS, fr } from "date-fns/locale";
 import { useTranslations } from "next-intl";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 type ActiveProposalsViewProps = {
   selectedEpochId?: string;
@@ -25,27 +24,87 @@ export function ActiveProposalsView({
   onSelectEpoch,
 }: ActiveProposalsViewProps) {
   const t = useTranslations("Home");
+  const [sortBy, setSortBy] = useState<"sol" | "date" | "name">("sol");
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
 
   const sortedFilteredProposals = useMemo(() => {
-    return [...filteredProposals].sort((a, b) => b.solRaised - a.solRaised);
-  }, [filteredProposals]);
+    let sorted = [...filteredProposals];
+
+    switch (sortBy) {
+      case "date":
+        sorted.sort((a, b) => {
+          return sortOrder === "desc"
+            ? b.creationTimestamp - a.creationTimestamp
+            : a.creationTimestamp - b.creationTimestamp;
+        });
+        break;
+      case "name":
+        sorted.sort((a, b) => {
+          return sortOrder === "desc"
+            ? b.tokenName.localeCompare(a.tokenName)
+            : a.tokenName.localeCompare(b.tokenName);
+        });
+        break;
+      default: // "sol"
+        sorted.sort((a, b) => {
+          return sortOrder === "desc"
+            ? b.solRaised - a.solRaised
+            : a.solRaised - b.solRaised;
+        });
+    }
+
+    return sorted;
+  }, [filteredProposals, sortBy, sortOrder]);
 
   return (
     <>
-      {/* Container for Epoch Selector and Details Card */}
-      <div className="flex flex-wrap items-center justify-between gap-4 mb-6">
+      <div className="flex flex-col sm:flex-row justify-between items-center gap-4 mb-6">
         <EpochSelector
           selectedEpochId={selectedEpochId}
           onSelect={onSelectEpoch}
           activeOnly
         />
 
-        {/* Epoch Details Card - remove its own margins */}
+        {selectedEpochDetails && (
+          <div className="flex flex-wrap gap-2">
+            <select
+              className="px-4 py-2 rounded-lg bg-gray-800/50 hover:bg-gray-800 
+                        text-gray-300 border border-gray-700 transition-colors"
+              value={sortBy}
+              onChange={(e) =>
+                setSortBy(e.target.value as "sol" | "date" | "name")
+              }
+            >
+              <option value="sol">{t("sortBySolana")}</option>
+              <option value="date">{t("sortByDate")}</option>
+              <option value="name">{t("sortByName")}</option>
+            </select>
+            <select
+              className="px-4 py-2 rounded-lg bg-gray-800/50 hover:bg-gray-800 
+                        text-gray-300 border border-gray-700 transition-colors"
+              value={sortOrder}
+              onChange={(e) => setSortOrder(e.target.value as "asc" | "desc")}
+            >
+              <option value="desc">
+                {sortBy === "date" ? t("sortByNewest") : t("sortByDesc")}
+              </option>
+              <option value="asc">
+                {sortBy === "date" ? t("sortByOldest") : t("sortByAsc")}
+              </option>
+            </select>
+          </div>
+        )}
+      </div>
+
+      {/* Container for Epoch Selector and Details Card */}
+      <div className="flex flex-wrap items-center justify-between gap-4 mb-6">
         {selectedEpochDetails && (
           <div className="px-6 py-2 bg-gray-800/50 rounded-xl border border-gray-700 flex-grow md:flex-grow-0">
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               <div className="text-center">
-                <h3 className="text-sm text-gray-400 mb-1">{t("epochStart")}</h3>
+                <h3 className="text-sm text-gray-400 mb-1">
+                  {t("epochStart")}
+                </h3>
                 <p className="text-lg font-semibold">
                   {format(
                     new Date(selectedEpochDetails.startTime * 1000),
@@ -60,9 +119,13 @@ export function ActiveProposalsView({
               <div className="text-center">
                 <h3 className="text-sm text-gray-400 mb-1">{t("epochEnd")}</h3>
                 <p className="text-lg font-semibold">
-                  {format(new Date(selectedEpochDetails.endTime * 1000), "PPp", {
-                    locale: locale === "fr" ? fr : enUS,
-                  })}
+                  {format(
+                    new Date(selectedEpochDetails.endTime * 1000),
+                    "PPp",
+                    {
+                      locale: locale === "fr" ? fr : enUS,
+                    }
+                  )}
                 </p>
               </div>
 
@@ -87,15 +150,12 @@ export function ActiveProposalsView({
         <div className="flex flex-col gap-4">
           {sortedFilteredProposals.map((proposal, index) => {
             let borderClass = "";
-
             if (index < 3) {
               borderClass = "gradient-border gradient-border-green";
             } else if (index < 7) {
               borderClass = "gradient-border gradient-border-blue";
-            } else if (index < 10) {
-              borderClass = "gradient-border gradient-border-blue";
             } else {
-              borderClass = "border-1 border-red-900";
+              borderClass = "border-1 border-gray-700";
             }
 
             return (

--- a/front/components/home/ProposalCard.tsx
+++ b/front/components/home/ProposalCard.tsx
@@ -2,6 +2,8 @@ import { ProposalState } from "@/context/ProgramContext";
 import { cn } from "@/lib/utils";
 import { ipfsToHttp } from "@/utils/ImageStorage";
 import { LAMPORTS_PER_SOL } from "@solana/web3.js";
+import { formatDistanceToNow } from "date-fns";
+import { enUS, fr } from "date-fns/locale";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import Link from "next/link";
@@ -19,7 +21,15 @@ export function ProposalCard({
 }: ProposalCardProps) {
   const t = useTranslations("Home");
 
-  // Card content definition remains the same
+  // Format relative date (e.g. "2 hours ago")
+  const formatRelativeDate = (timestamp: number) => {
+    const date = new Date(timestamp * 1000);
+    return formatDistanceToNow(date, {
+      addSuffix: true,
+      locale: locale === "fr" ? fr : enUS,
+    });
+  };
+
   const CardContent = (
     <>
       <div className="relative w-24 h-24 bg-gray-800 rounded-lg overflow-hidden">
@@ -49,16 +59,23 @@ export function ProposalCard({
           ${proposal.tokenSymbol}
         </p>
         <h3 className="text-md text-gray-200">{proposal.tokenName}</h3>
-        <p className="text-xs text-gray-500 pt-1">
-          {t("by")}{" "}
-          <Link
-            href={`/${locale}/profile/${proposal.creator.toString()}`}
-            className="hover:underline hover:text-[#e6d3ba] transition-colors"
-          >
-            {proposal.creator.toString().slice(0, 4)}...
-            {proposal.creator.toString().slice(-4)}
-          </Link>
-        </p>
+        <div className="space-y-0.5">
+          <p className="text-xs text-gray-500">
+            {t("by")}{" "}
+            <Link
+              href={`/${locale}/profile/${proposal.creator.toString()}`}
+              className="hover:underline hover:text-[#e6d3ba] transition-colors"
+            >
+              {proposal.creator.toString().slice(0, 4)}...
+              {proposal.creator.toString().slice(-4)}
+            </Link>
+          </p>
+          <p className="text-xs text-gray-500">
+            {t("createdAgo", {
+              time: formatRelativeDate(proposal.creationTimestamp),
+            })}
+          </p>
+        </div>
       </div>
       {/* Section Droite : Réorganisée en Ligne (Bouton à gauche, Stats à droite) */}
       <div className="flex items-center gap-4 ml-auto flex-shrink-0">

--- a/front/context/idl/programs.json
+++ b/front/context/idl/programs.json
@@ -8,6 +8,90 @@
   },
   "instructions": [
     {
+      "name": "add_admin",
+      "discriminator": [
+        177,
+        236,
+        33,
+        205,
+        124,
+        152,
+        55,
+        186
+      ],
+      "accounts": [
+        {
+          "name": "treasury_roles",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "new_admin",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "add_treasury_role",
+      "discriminator": [
+        250,
+        167,
+        53,
+        191,
+        17,
+        177,
+        200,
+        116
+      ],
+      "accounts": [
+        {
+          "name": "treasury_roles",
+          "docs": [
+            "The TreasuryRoles account (must be mutable)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "The admin authority (must be present in authorities)"
+          ],
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "role_type",
+          "type": {
+            "defined": {
+              "name": "RoleType"
+            }
+          }
+        },
+        {
+          "name": "pubkey",
+          "type": "pubkey"
+        },
+        {
+          "name": "withdrawal_limit",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "withdrawal_period",
+          "type": {
+            "option": "i64"
+          }
+        }
+      ]
+    },
+    {
       "name": "create_proposal",
       "discriminator": [
         132,
@@ -61,6 +145,27 @@
         },
         {
           "name": "epoch"
+        },
+        {
+          "name": "treasury",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  114,
+                  101,
+                  97,
+                  115,
+                  117,
+                  114,
+                  121
+                ]
+              }
+            ]
+          }
         },
         {
           "name": "system_program",
@@ -153,59 +258,6 @@
       ]
     },
     {
-      "name": "get_epoch_state",
-      "discriminator": [
-        143,
-        2,
-        34,
-        250,
-        77,
-        45,
-        31,
-        154
-      ],
-      "accounts": [
-        {
-          "name": "epoch_management"
-        }
-      ],
-      "args": [
-        {
-          "name": "epoch_id",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "get_proposal_details",
-      "discriminator": [
-        236,
-        135,
-        27,
-        97,
-        207,
-        192,
-        173,
-        128
-      ],
-      "accounts": [
-        {
-          "name": "proposal",
-          "writable": true
-        },
-        {
-          "name": "system_program",
-          "address": "11111111111111111111111111111111"
-        }
-      ],
-      "args": [
-        {
-          "name": "proposal_id",
-          "type": "u64"
-        }
-      ]
-    },
-    {
       "name": "initialize",
       "discriminator": [
         175,
@@ -270,6 +322,116 @@
       ]
     },
     {
+      "name": "initialize_treasury",
+      "discriminator": [
+        124,
+        186,
+        211,
+        195,
+        85,
+        165,
+        129,
+        166
+      ],
+      "accounts": [
+        {
+          "name": "treasury",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  114,
+                  101,
+                  97,
+                  115,
+                  117,
+                  114,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "initial_authority",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "initialize_treasury_roles",
+      "discriminator": [
+        127,
+        138,
+        198,
+        114,
+        99,
+        90,
+        115,
+        181
+      ],
+      "accounts": [
+        {
+          "name": "treasury_roles",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  114,
+                  101,
+                  97,
+                  115,
+                  117,
+                  114,
+                  121,
+                  95,
+                  114,
+                  111,
+                  108,
+                  101,
+                  115
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "authorities",
+          "type": {
+            "vec": "pubkey"
+          }
+        }
+      ]
+    },
+    {
       "name": "mark_epoch_processed",
       "discriminator": [
         210,
@@ -311,6 +473,194 @@
         }
       ],
       "args": []
+    },
+    {
+      "name": "reclaim_support",
+      "discriminator": [
+        23,
+        123,
+        152,
+        130,
+        171,
+        255,
+        2,
+        10
+      ],
+      "accounts": [
+        {
+          "name": "user",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_proposal",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  112,
+                  111,
+                  115,
+                  97,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_proposal.creator",
+                "account": "TokenProposal"
+              },
+              {
+                "kind": "account",
+                "path": "token_proposal.epoch_id",
+                "account": "TokenProposal"
+              },
+              {
+                "kind": "account",
+                "path": "token_proposal.token_name",
+                "account": "TokenProposal"
+              }
+            ]
+          }
+        },
+        {
+          "name": "user_proposal_support",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  117,
+                  112,
+                  112,
+                  111,
+                  114,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_proposal.epoch_id",
+                "account": "TokenProposal"
+              },
+              {
+                "kind": "account",
+                "path": "user"
+              },
+              {
+                "kind": "account",
+                "path": "token_proposal"
+              }
+            ]
+          }
+        },
+        {
+          "name": "epoch_management",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  112,
+                  111,
+                  99,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_proposal.epoch_id",
+                "account": "TokenProposal"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "remove_admin",
+      "discriminator": [
+        74,
+        202,
+        71,
+        106,
+        252,
+        31,
+        72,
+        183
+      ],
+      "accounts": [
+        {
+          "name": "treasury_roles",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "admin_to_remove",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "remove_treasury_role",
+      "discriminator": [
+        90,
+        106,
+        204,
+        106,
+        66,
+        58,
+        239,
+        74
+      ],
+      "accounts": [
+        {
+          "name": "treasury_roles",
+          "docs": [
+            "The TreasuryRoles account (must be mutable)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "The admin authority (must be present in authorities)"
+          ],
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "role_type",
+          "type": {
+            "defined": {
+              "name": "RoleType"
+            }
+          }
+        },
+        {
+          "name": "pubkey",
+          "type": "pubkey"
+        }
+      ]
     },
     {
       "name": "start_epoch",
@@ -431,6 +781,27 @@
           }
         },
         {
+          "name": "treasury",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  114,
+                  101,
+                  97,
+                  115,
+                  117,
+                  114,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
         }
@@ -480,6 +851,61 @@
           }
         }
       ]
+    },
+    {
+      "name": "update_treasury_role",
+      "discriminator": [
+        76,
+        67,
+        55,
+        141,
+        212,
+        110,
+        148,
+        140
+      ],
+      "accounts": [
+        {
+          "name": "treasury_roles",
+          "docs": [
+            "The TreasuryRoles account (must be mutable)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "The admin authority (must be present in authorities)"
+          ],
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "role_type",
+          "type": {
+            "defined": {
+              "name": "RoleType"
+            }
+          }
+        },
+        {
+          "name": "pubkey",
+          "type": "pubkey"
+        },
+        {
+          "name": "withdrawal_limit",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "withdrawal_period",
+          "type": {
+            "option": "i64"
+          }
+        }
+      ]
     }
   ],
   "accounts": [
@@ -523,6 +949,32 @@
       ]
     },
     {
+      "name": "Treasury",
+      "discriminator": [
+        238,
+        239,
+        123,
+        238,
+        89,
+        1,
+        168,
+        253
+      ]
+    },
+    {
+      "name": "TreasuryRoles",
+      "discriminator": [
+        68,
+        16,
+        45,
+        143,
+        74,
+        61,
+        98,
+        193
+      ]
+    },
+    {
       "name": "UserProposalSupport",
       "discriminator": [
         255,
@@ -548,19 +1000,6 @@
         233,
         164,
         252
-      ]
-    },
-    {
-      "name": "ProposalDetailsRetrieved",
-      "discriminator": [
-        81,
-        200,
-        254,
-        55,
-        73,
-        7,
-        79,
-        217
       ]
     }
   ],
@@ -684,6 +1123,61 @@
       "code": 6023,
       "name": "Unauthorized",
       "msg": "Unauthorized: Only the admin can perform this action."
+    },
+    {
+      "code": 6024,
+      "name": "ProposalNotRejected",
+      "msg": "La proposition doit être rejetée pour pouvoir réclamer les fonds."
+    },
+    {
+      "code": 6025,
+      "name": "ProposalMismatch",
+      "msg": "Le compte de support ne correspond pas à la proposition fournie."
+    },
+    {
+      "code": 6026,
+      "name": "NothingToReclaim",
+      "msg": "Il n'y a aucun montant à réclamer dans ce compte de support."
+    },
+    {
+      "code": 6027,
+      "name": "InsufficientProposalFunds",
+      "msg": "Fonds insuffisants dans le compte de la proposition pour effectuer le remboursement."
+    },
+    {
+      "code": 6028,
+      "name": "EpochNotProcessedYet",
+      "msg": "L'époque n'a pas encore été marquée comme traitée par le crank."
+    },
+    {
+      "code": 6029,
+      "name": "CouldNotRetrieveBump",
+      "msg": "Could not retrieve bump seed."
+    },
+    {
+      "code": 6030,
+      "name": "RoleAlreadyExists",
+      "msg": "Ce rôle existe déjà pour ce wallet."
+    },
+    {
+      "code": 6031,
+      "name": "RolesCapacityExceeded",
+      "msg": "The maximum number of roles has been reached."
+    },
+    {
+      "code": 6032,
+      "name": "CalculationOverflow",
+      "msg": "A calculation resulted in an overflow."
+    },
+    {
+      "code": 6033,
+      "name": "AmountTooLowToCoverFees",
+      "msg": "The support amount is insufficient to cover fees."
+    },
+    {
+      "code": 6034,
+      "name": "FeeCannotBeZero",
+      "msg": "The calculated fee amount cannot be zero."
     }
   ],
   "types": [
@@ -765,72 +1259,6 @@
       }
     },
     {
-      "name": "ProposalDetailsRetrieved",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "epoch_id",
-            "type": "u64"
-          },
-          {
-            "name": "creator",
-            "type": "pubkey"
-          },
-          {
-            "name": "token_name",
-            "type": "string"
-          },
-          {
-            "name": "token_symbol",
-            "type": "string"
-          },
-          {
-            "name": "description",
-            "type": "string"
-          },
-          {
-            "name": "image_url",
-            "type": {
-              "option": "string"
-            }
-          },
-          {
-            "name": "total_supply",
-            "type": "u64"
-          },
-          {
-            "name": "creator_allocation",
-            "type": "u8"
-          },
-          {
-            "name": "supporter_allocation",
-            "type": "u8"
-          },
-          {
-            "name": "sol_raised",
-            "type": "u64"
-          },
-          {
-            "name": "total_contributions",
-            "type": "u64"
-          },
-          {
-            "name": "lockup_period",
-            "type": "i64"
-          },
-          {
-            "name": "status",
-            "type": {
-              "defined": {
-                "name": "ProposalStatus"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
       "name": "ProposalStatus",
       "type": {
         "kind": "enum",
@@ -843,6 +1271,37 @@
           },
           {
             "name": "Rejected"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RoleType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Admin"
+          },
+          {
+            "name": "CategoryManager",
+            "fields": [
+              {
+                "defined": {
+                  "name": "TreasuryCategory"
+                }
+              }
+            ]
+          },
+          {
+            "name": "Withdrawer",
+            "fields": [
+              {
+                "defined": {
+                  "name": "TreasuryCategory"
+                }
+              }
+            ]
           }
         ]
       }
@@ -903,12 +1362,166 @@
             "type": "i64"
           },
           {
+            "name": "creation_timestamp",
+            "type": "i64"
+          },
+          {
             "name": "status",
             "type": {
               "defined": {
                 "name": "ProposalStatus"
               }
             }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Treasury",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "marketing",
+            "type": {
+              "defined": {
+                "name": "TreasurySubAccount"
+              }
+            }
+          },
+          {
+            "name": "team",
+            "type": {
+              "defined": {
+                "name": "TreasurySubAccount"
+              }
+            }
+          },
+          {
+            "name": "operations",
+            "type": {
+              "defined": {
+                "name": "TreasurySubAccount"
+              }
+            }
+          },
+          {
+            "name": "investments",
+            "type": {
+              "defined": {
+                "name": "TreasurySubAccount"
+              }
+            }
+          },
+          {
+            "name": "crank",
+            "type": {
+              "defined": {
+                "name": "TreasurySubAccount"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TreasuryCategory",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Marketing"
+          },
+          {
+            "name": "Team"
+          },
+          {
+            "name": "Operations"
+          },
+          {
+            "name": "Investments"
+          },
+          {
+            "name": "Crank"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TreasuryRole",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "role_type",
+            "type": {
+              "defined": {
+                "name": "RoleType"
+              }
+            }
+          },
+          {
+            "name": "pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "withdrawal_limit",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "withdrawal_period",
+            "type": {
+              "option": "i64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TreasuryRoles",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authorities",
+            "docs": [
+              "List of up to 3 admin authorities allowed to manage roles"
+            ],
+            "type": {
+              "vec": "pubkey"
+            }
+          },
+          {
+            "name": "roles",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "TreasuryRole"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TreasurySubAccount",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "sol_balance",
+            "type": "u64"
+          },
+          {
+            "name": "last_withdrawal",
+            "type": "i64"
           }
         ]
       }

--- a/front/context/types/programs.ts
+++ b/front/context/types/programs.ts
@@ -14,6 +14,90 @@ export type Programs = {
   },
   "instructions": [
     {
+      "name": "addAdmin",
+      "discriminator": [
+        177,
+        236,
+        33,
+        205,
+        124,
+        152,
+        55,
+        186
+      ],
+      "accounts": [
+        {
+          "name": "treasuryRoles",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "newAdmin",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "addTreasuryRole",
+      "discriminator": [
+        250,
+        167,
+        53,
+        191,
+        17,
+        177,
+        200,
+        116
+      ],
+      "accounts": [
+        {
+          "name": "treasuryRoles",
+          "docs": [
+            "The TreasuryRoles account (must be mutable)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "The admin authority (must be present in authorities)"
+          ],
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "roleType",
+          "type": {
+            "defined": {
+              "name": "roleType"
+            }
+          }
+        },
+        {
+          "name": "pubkey",
+          "type": "pubkey"
+        },
+        {
+          "name": "withdrawalLimit",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "withdrawalPeriod",
+          "type": {
+            "option": "i64"
+          }
+        }
+      ]
+    },
+    {
       "name": "createProposal",
       "discriminator": [
         132,
@@ -67,6 +151,27 @@ export type Programs = {
         },
         {
           "name": "epoch"
+        },
+        {
+          "name": "treasury",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  114,
+                  101,
+                  97,
+                  115,
+                  117,
+                  114,
+                  121
+                ]
+              }
+            ]
+          }
         },
         {
           "name": "systemProgram",
@@ -159,59 +264,6 @@ export type Programs = {
       ]
     },
     {
-      "name": "getEpochState",
-      "discriminator": [
-        143,
-        2,
-        34,
-        250,
-        77,
-        45,
-        31,
-        154
-      ],
-      "accounts": [
-        {
-          "name": "epochManagement"
-        }
-      ],
-      "args": [
-        {
-          "name": "epochId",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "getProposalDetails",
-      "discriminator": [
-        236,
-        135,
-        27,
-        97,
-        207,
-        192,
-        173,
-        128
-      ],
-      "accounts": [
-        {
-          "name": "proposal",
-          "writable": true
-        },
-        {
-          "name": "systemProgram",
-          "address": "11111111111111111111111111111111"
-        }
-      ],
-      "args": [
-        {
-          "name": "proposalId",
-          "type": "u64"
-        }
-      ]
-    },
-    {
       "name": "initialize",
       "discriminator": [
         175,
@@ -276,6 +328,116 @@ export type Programs = {
       ]
     },
     {
+      "name": "initializeTreasury",
+      "discriminator": [
+        124,
+        186,
+        211,
+        195,
+        85,
+        165,
+        129,
+        166
+      ],
+      "accounts": [
+        {
+          "name": "treasury",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  114,
+                  101,
+                  97,
+                  115,
+                  117,
+                  114,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "systemProgram",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "initialAuthority",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "initializeTreasuryRoles",
+      "discriminator": [
+        127,
+        138,
+        198,
+        114,
+        99,
+        90,
+        115,
+        181
+      ],
+      "accounts": [
+        {
+          "name": "treasuryRoles",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  114,
+                  101,
+                  97,
+                  115,
+                  117,
+                  114,
+                  121,
+                  95,
+                  114,
+                  111,
+                  108,
+                  101,
+                  115
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "systemProgram",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "authorities",
+          "type": {
+            "vec": "pubkey"
+          }
+        }
+      ]
+    },
+    {
       "name": "markEpochProcessed",
       "discriminator": [
         210,
@@ -317,6 +479,194 @@ export type Programs = {
         }
       ],
       "args": []
+    },
+    {
+      "name": "reclaimSupport",
+      "discriminator": [
+        23,
+        123,
+        152,
+        130,
+        171,
+        255,
+        2,
+        10
+      ],
+      "accounts": [
+        {
+          "name": "user",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "tokenProposal",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  112,
+                  111,
+                  115,
+                  97,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_proposal.creator",
+                "account": "tokenProposal"
+              },
+              {
+                "kind": "account",
+                "path": "token_proposal.epoch_id",
+                "account": "tokenProposal"
+              },
+              {
+                "kind": "account",
+                "path": "token_proposal.token_name",
+                "account": "tokenProposal"
+              }
+            ]
+          }
+        },
+        {
+          "name": "userProposalSupport",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  117,
+                  112,
+                  112,
+                  111,
+                  114,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_proposal.epoch_id",
+                "account": "tokenProposal"
+              },
+              {
+                "kind": "account",
+                "path": "user"
+              },
+              {
+                "kind": "account",
+                "path": "tokenProposal"
+              }
+            ]
+          }
+        },
+        {
+          "name": "epochManagement",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  112,
+                  111,
+                  99,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_proposal.epoch_id",
+                "account": "tokenProposal"
+              }
+            ]
+          }
+        },
+        {
+          "name": "systemProgram",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "removeAdmin",
+      "discriminator": [
+        74,
+        202,
+        71,
+        106,
+        252,
+        31,
+        72,
+        183
+      ],
+      "accounts": [
+        {
+          "name": "treasuryRoles",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "adminToRemove",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "removeTreasuryRole",
+      "discriminator": [
+        90,
+        106,
+        204,
+        106,
+        66,
+        58,
+        239,
+        74
+      ],
+      "accounts": [
+        {
+          "name": "treasuryRoles",
+          "docs": [
+            "The TreasuryRoles account (must be mutable)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "The admin authority (must be present in authorities)"
+          ],
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "roleType",
+          "type": {
+            "defined": {
+              "name": "roleType"
+            }
+          }
+        },
+        {
+          "name": "pubkey",
+          "type": "pubkey"
+        }
+      ]
     },
     {
       "name": "startEpoch",
@@ -437,6 +787,27 @@ export type Programs = {
           }
         },
         {
+          "name": "treasury",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  114,
+                  101,
+                  97,
+                  115,
+                  117,
+                  114,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
           "name": "systemProgram",
           "address": "11111111111111111111111111111111"
         }
@@ -486,6 +857,61 @@ export type Programs = {
           }
         }
       ]
+    },
+    {
+      "name": "updateTreasuryRole",
+      "discriminator": [
+        76,
+        67,
+        55,
+        141,
+        212,
+        110,
+        148,
+        140
+      ],
+      "accounts": [
+        {
+          "name": "treasuryRoles",
+          "docs": [
+            "The TreasuryRoles account (must be mutable)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "The admin authority (must be present in authorities)"
+          ],
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "roleType",
+          "type": {
+            "defined": {
+              "name": "roleType"
+            }
+          }
+        },
+        {
+          "name": "pubkey",
+          "type": "pubkey"
+        },
+        {
+          "name": "withdrawalLimit",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "withdrawalPeriod",
+          "type": {
+            "option": "i64"
+          }
+        }
+      ]
     }
   ],
   "accounts": [
@@ -529,6 +955,32 @@ export type Programs = {
       ]
     },
     {
+      "name": "treasury",
+      "discriminator": [
+        238,
+        239,
+        123,
+        238,
+        89,
+        1,
+        168,
+        253
+      ]
+    },
+    {
+      "name": "treasuryRoles",
+      "discriminator": [
+        68,
+        16,
+        45,
+        143,
+        74,
+        61,
+        98,
+        193
+      ]
+    },
+    {
       "name": "userProposalSupport",
       "discriminator": [
         255,
@@ -554,19 +1006,6 @@ export type Programs = {
         233,
         164,
         252
-      ]
-    },
-    {
-      "name": "proposalDetailsRetrieved",
-      "discriminator": [
-        81,
-        200,
-        254,
-        55,
-        73,
-        7,
-        79,
-        217
       ]
     }
   ],
@@ -690,6 +1129,61 @@ export type Programs = {
       "code": 6023,
       "name": "unauthorized",
       "msg": "Unauthorized: Only the admin can perform this action."
+    },
+    {
+      "code": 6024,
+      "name": "proposalNotRejected",
+      "msg": "La proposition doit être rejetée pour pouvoir réclamer les fonds."
+    },
+    {
+      "code": 6025,
+      "name": "proposalMismatch",
+      "msg": "Le compte de support ne correspond pas à la proposition fournie."
+    },
+    {
+      "code": 6026,
+      "name": "nothingToReclaim",
+      "msg": "Il n'y a aucun montant à réclamer dans ce compte de support."
+    },
+    {
+      "code": 6027,
+      "name": "insufficientProposalFunds",
+      "msg": "Fonds insuffisants dans le compte de la proposition pour effectuer le remboursement."
+    },
+    {
+      "code": 6028,
+      "name": "epochNotProcessedYet",
+      "msg": "L'époque n'a pas encore été marquée comme traitée par le crank."
+    },
+    {
+      "code": 6029,
+      "name": "couldNotRetrieveBump",
+      "msg": "Could not retrieve bump seed."
+    },
+    {
+      "code": 6030,
+      "name": "roleAlreadyExists",
+      "msg": "Ce rôle existe déjà pour ce wallet."
+    },
+    {
+      "code": 6031,
+      "name": "rolesCapacityExceeded",
+      "msg": "The maximum number of roles has been reached."
+    },
+    {
+      "code": 6032,
+      "name": "calculationOverflow",
+      "msg": "A calculation resulted in an overflow."
+    },
+    {
+      "code": 6033,
+      "name": "amountTooLowToCoverFees",
+      "msg": "The support amount is insufficient to cover fees."
+    },
+    {
+      "code": 6034,
+      "name": "feeCannotBeZero",
+      "msg": "The calculated fee amount cannot be zero."
     }
   ],
   "types": [
@@ -771,72 +1265,6 @@ export type Programs = {
       }
     },
     {
-      "name": "proposalDetailsRetrieved",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "epochId",
-            "type": "u64"
-          },
-          {
-            "name": "creator",
-            "type": "pubkey"
-          },
-          {
-            "name": "tokenName",
-            "type": "string"
-          },
-          {
-            "name": "tokenSymbol",
-            "type": "string"
-          },
-          {
-            "name": "description",
-            "type": "string"
-          },
-          {
-            "name": "imageUrl",
-            "type": {
-              "option": "string"
-            }
-          },
-          {
-            "name": "totalSupply",
-            "type": "u64"
-          },
-          {
-            "name": "creatorAllocation",
-            "type": "u8"
-          },
-          {
-            "name": "supporterAllocation",
-            "type": "u8"
-          },
-          {
-            "name": "solRaised",
-            "type": "u64"
-          },
-          {
-            "name": "totalContributions",
-            "type": "u64"
-          },
-          {
-            "name": "lockupPeriod",
-            "type": "i64"
-          },
-          {
-            "name": "status",
-            "type": {
-              "defined": {
-                "name": "proposalStatus"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
       "name": "proposalStatus",
       "type": {
         "kind": "enum",
@@ -849,6 +1277,37 @@ export type Programs = {
           },
           {
             "name": "rejected"
+          }
+        ]
+      }
+    },
+    {
+      "name": "roleType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "admin"
+          },
+          {
+            "name": "categoryManager",
+            "fields": [
+              {
+                "defined": {
+                  "name": "treasuryCategory"
+                }
+              }
+            ]
+          },
+          {
+            "name": "withdrawer",
+            "fields": [
+              {
+                "defined": {
+                  "name": "treasuryCategory"
+                }
+              }
+            ]
           }
         ]
       }
@@ -909,12 +1368,166 @@ export type Programs = {
             "type": "i64"
           },
           {
+            "name": "creationTimestamp",
+            "type": "i64"
+          },
+          {
             "name": "status",
             "type": {
               "defined": {
                 "name": "proposalStatus"
               }
             }
+          }
+        ]
+      }
+    },
+    {
+      "name": "treasury",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "marketing",
+            "type": {
+              "defined": {
+                "name": "treasurySubAccount"
+              }
+            }
+          },
+          {
+            "name": "team",
+            "type": {
+              "defined": {
+                "name": "treasurySubAccount"
+              }
+            }
+          },
+          {
+            "name": "operations",
+            "type": {
+              "defined": {
+                "name": "treasurySubAccount"
+              }
+            }
+          },
+          {
+            "name": "investments",
+            "type": {
+              "defined": {
+                "name": "treasurySubAccount"
+              }
+            }
+          },
+          {
+            "name": "crank",
+            "type": {
+              "defined": {
+                "name": "treasurySubAccount"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "treasuryCategory",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "marketing"
+          },
+          {
+            "name": "team"
+          },
+          {
+            "name": "operations"
+          },
+          {
+            "name": "investments"
+          },
+          {
+            "name": "crank"
+          }
+        ]
+      }
+    },
+    {
+      "name": "treasuryRole",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "roleType",
+            "type": {
+              "defined": {
+                "name": "roleType"
+              }
+            }
+          },
+          {
+            "name": "pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "withdrawalLimit",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "withdrawalPeriod",
+            "type": {
+              "option": "i64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "treasuryRoles",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authorities",
+            "docs": [
+              "List of up to 3 admin authorities allowed to manage roles"
+            ],
+            "type": {
+              "vec": "pubkey"
+            }
+          },
+          {
+            "name": "roles",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "treasuryRole"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "treasurySubAccount",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "solBalance",
+            "type": "u64"
+          },
+          {
+            "name": "lastWithdrawal",
+            "type": "i64"
           }
         ]
       }

--- a/front/messages/en.json
+++ b/front/messages/en.json
@@ -120,6 +120,8 @@
     "timeLeft": "Time remaining",
     "proposalCount": "{count, plural, =0 {No proposals} one {# proposal} other {# proposals}}",
     "proposalsList": "Proposals",
+    "sortByDesc": "Highest first",
+    "sortByAsc": "Lowest first",
     "sortBySolana": "Sort by SOL raised",
     "sortByName": "Sort by name",
     "sortByDate": "Sort by date",

--- a/front/messages/en.json
+++ b/front/messages/en.json
@@ -123,6 +123,8 @@
     "sortBySolana": "Sort by SOL raised",
     "sortByName": "Sort by name",
     "sortByDate": "Sort by date",
+    "sortByNewest": "Newest first",
+    "sortByOldest": "Oldest first",
     "solanaRaised": "{amount} SOL",
     "epochId": "Epoch",
     "noImage": "No image",
@@ -142,7 +144,12 @@
     "rank": "Rank #{rank}",
     "qualifiedForPhase2": "Qualified for Phase 2",
     "contributions": "{count, plural, =0 {No contributions} one {# contribution} other {# contributions}}",
-    "errorLoadingProposals": "Error loading proposals"
+    "errorLoadingProposals": "Error loading proposals",
+    "proposalStatus": {
+      "active": "Active",
+      "validated": "Validated",
+      "rejected": "Rejected"
+    }
   },
   "Treasury": {
     "title": "Treasury",
@@ -208,7 +215,8 @@
     "proposalNotActive": "This proposal is no longer active",
     "claimButton": "Claim",
     "claimSuccess": "Funds claimed successfully!",
-    "claimError": "Error claiming funds"
+    "claimError": "Error claiming funds",
+    "creationDate": "Creation date"
   },
   "EpochForm": {
     "title": "Create New Epoch",
@@ -381,9 +389,11 @@
     "createdTokens": "Created Tokens",
     "supportedTokens": "Supported Tokens",
     "sortBy": {
-      "date": "Sort by Date",
-      "name": "Sort by Name",
-      "amount": "Sort by Amount"
+      "date": "Date",
+      "name": "Name",
+      "amount": "Amount",
+      "newest": "Newest",
+      "oldest": "Oldest"
     },
     "noCreatedTokens": "No tokens created yet",
     "noSupportedTokens": "No tokens supported yet",
@@ -405,7 +415,8 @@
       "previous": "Previous",
       "next": "Next",
       "showing": "Showing {start} to {end} of {total} tokens"
-    }
+    },
+    "createdAt": "{date}"
   },
   "WalletButton": {
     "connect": "Connect Wallet",

--- a/front/messages/fr.json
+++ b/front/messages/fr.json
@@ -123,6 +123,8 @@
     "sortBySolana": "Trier par SOL levés",
     "sortByName": "Trier par nom",
     "sortByDate": "Trier par date",
+    "sortByNewest": "Plus récent",
+    "sortByOldest": "Plus ancien",
     "solanaRaised": "{amount} SOL",
     "epochId": "Epoch",
     "noImage": "Pas d'image",
@@ -142,7 +144,12 @@
     "rank": "Rang #{rank}",
     "qualifiedForPhase2": "Qualifié pour la Phase 2",
     "contributions": "{count, plural, =0 {Aucune contribution} one {# contribution} other {# contributions}}",
-    "errorLoadingProposals": "Erreur lors du chargement des propositions"
+    "errorLoadingProposals": "Erreur lors du chargement des propositions",
+    "proposalStatus": {
+      "active": "Active",
+      "validated": "Validée",
+      "rejected": "Rejetée"
+    }
   },
   "Treasury": {
     "title": "Trésorerie",
@@ -208,7 +215,8 @@
     "proposalNotActive": "Cette proposition n'est plus active",
     "claimButton": "Récupérer",
     "claimSuccess": "Fonds récupérés avec succès !",
-    "claimError": "Erreur lors de la récupération des fonds"
+    "claimError": "Erreur lors de la récupération des fonds",
+    "creationDate": "Date de création"
   },
   "EpochForm": {
     "title": "Créer un Nouvel Epoch",
@@ -380,7 +388,9 @@
     "sortBy": {
       "date": "Trier par Date",
       "name": "Trier par Nom",
-      "amount": "Trier par Montant"
+      "amount": "Trier par Montant",
+      "newest": "Plus récent",
+      "oldest": "Plus ancien"
     },
     "noCreatedTokens": "Aucun token créé",
     "noSupportedTokens": "Aucun token soutenu",
@@ -395,7 +405,6 @@
       "validated": "Validée",
       "rejected": "Rejetée"
     },
-
     "claimButton": "Récupérer",
     "claimSuccess": "Fonds récupérés avec succès !",
     "claimError": "Erreur lors de la récupération des fonds",
@@ -403,7 +412,8 @@
       "previous": "Précédent",
       "next": "Suivant",
       "showing": "Affichage de {start} à {end} sur {total} tokens"
-    }
+    },
+    "createdAt": "{date}"
   },
   "WalletButton": {
     "connect": "Connecter Wallet",

--- a/front/messages/fr.json
+++ b/front/messages/fr.json
@@ -120,6 +120,8 @@
     "timeLeft": "Temps restant",
     "proposalCount": "{count, plural, =0 {Aucune proposition} one {# proposition} other {# propositions}}",
     "proposalsList": "Propositions",
+    "sortByDesc": "Plus élevé",
+    "sortByAsc": "Plus faible",
     "sortBySolana": "Trier par SOL levés",
     "sortByName": "Trier par nom",
     "sortByDate": "Trier par date",


### PR DESCRIPTION
### 🧾 Description

Cette PR ajoute la possibilité de trier les listes de **propositions de tokens** par **timestamp de création (`creationTimestamp`)**, à la fois sur la **page d'accueil (Home)** et sur la **page de profil (Profile)**.

Cette PR ajoute en complément un fichier .env.example dans le répertoire /front pour clarifier les variables d'environnement à déclarer pour faire fonctionner le projet.

Objectif : 
  -Permettre aux utilisateurs de consulter les **propositions les plus récentes** ou **les plus anciennes** selon leurs besoins, avec une granularité temporelle fine (plus précise que le `epoch_id`).
  -Simplifier la compréhension des variables d'environnement de la partie front

---

### 🔧 Changements principaux

#### 📦 Données & backend
- Utilisation du nouveau champ `creationTimestamp` (ajouté dans la PR backend #131).
- Les appels à `useProposals`, `useUserProposals`, etc., exposent désormais `creationTimestamp`.
- Ajout d'un .env.example pour avoir une base de déclaration des variables d'environnement dans /front

#### 💡 Logique de tri
- Implémentation d’une fonction de tri côté client sur la base de `creationTimestamp`.
- Deux ordres disponibles : `Plus récentes` (tri décroissant), `Plus anciennes` (tri croissant).
- Ordre par défaut : **Plus récentes**.

#### 🖥️ Interface utilisateur (UI)
- **Page Home** :
  - Ajout d’un menu déroulant en haut de la liste de propositions pour sélectionner le tri.
- **Page Profile** :
  - Ajout des mêmes options de tri dans les sections :
    - "Mes propositions créées"
    - "Propositions supportées"

- Design du menu en accord avec l’identité visuelle existante (boutons sobres, intégration fluide dans l’interface).

---

### 🧪 Comment tester

1. Lancer le front (`npm run dev`).
2. Aller sur la page d'accueil et/ou une page profil utilisateur.
3. Interagir avec le **menu de tri** :
   - Sélectionner "Plus récentes" → les dernières propositions doivent apparaître en haut.
   - Sélectionner "Plus anciennes" → les premières propositions doivent apparaître en haut.
4. Vérifier que le comportement est cohérent, sans erreurs ni effet de flicker.


---

### 📌 Lié à

- Issue : [#132 - Tri par timestamp des proposals](https://github.com/pylejeune/norug-fun/issues/132)
- Backend : PR [#131 - Add creation timestamp to TokenProposal](https://github.com/pylejeune/norug-fun/pull/131)

---

## 👥 Revue

- **Relecteurs suggérés** : @pylejeune @AlexLakarm  
- **Domaines concernés** :
  - `front/.env.example` 
  - `front/.gitignore` 
  - `front/app/[locale]/profile/[id]/page.tsx` 
  - `front/app/[locale]/proposal/[id]/page.tsx` 
  - `front/context/ProgramContext.tsx` 
  - `front/components/home/ActiveProposalsView.tsx` 
  - `front/components/home/ProposalCard.tsx` 
  - `front/messages/fr.json` 
  - `front/messages/en.json` 
  - `front/context/types/programs.ts` 
  - `front/context/idl/programs.json` 

---

### ✅ Checklist

- [x] Affichage de `creationTimestamp` sur les propositions
- [x] Menu de tri fonctionnel sur Home
- [x] Menu de tri fonctionnel sur Profil
- [x] Logique de tri stable (asc / desc)
- [x] Responsive et intégré visuellement
- [x] Code testé et factorisé

---

### 📸 Captures d’écran

Vue depuis la page Home:
<img width="210" alt="image" src="https://github.com/user-attachments/assets/d4875a38-072b-490e-9a60-52682976919a" />

Vue depuis la page Profile:
<img width="182" alt="image" src="https://github.com/user-attachments/assets/247705d8-5419-4f21-9948-3740127a4371" />
Vue des filtres de la page Profile:
<img width="282" alt="image" src="https://github.com/user-attachments/assets/81a93d6d-f22e-4157-8cdd-c0249926c19b" />

Vue depuis la page proposalDetail:
<img width="629" alt="image" src="https://github.com/user-attachments/assets/ff3280c0-3875-4008-ac6f-30bbc98f8bdf" />

---

## 🗒️ Notes complémentaires

- Mise à jour de l'IDL importé dans le front pour pouvoir utiliser le nouvel attribut timestamp
- La homePage sera entièrement retravaillé par la suite
- En localnet, le program renvoit des timestamps avec plusieurs heures d'écart avec la réalité (à contrôler en devnet)