### PR TITLE
169 feature prevent merge pr

### DIFF
--- a/.github/workflows/prevent-merge.yml
+++ b/.github/workflows/prevent-merge.yml
@@ -1,0 +1,88 @@
+name: Prevent Merge Without Issue in Review
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, closed]
+
+jobs:
+  check-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for associated issue
+        id: check_issue
+        run: |
+          ISSUE_NUMBER=$(echo "${{ github.event.pull_request.body }}" | grep -oE "#[0-9]+" | head -n 1 | tr -d '#')
+          if [ -z "$ISSUE_NUMBER" ]; then
+            echo "No issue number found in the pull request description."
+            exit 1
+          fi
+          echo "Issue number found: $ISSUE_NUMBER"
+          echo "::set-output name=issue_number::$ISSUE_NUMBER"
+
+      - name: Check if issue is in review column
+        id: check_review
+        run: |
+          ISSUE_NUMBER=${{ steps.check_issue.outputs.issue_number }}
+          PROJECT_ID="your_project_id" # Remplacez par l'ID de votre projet
+          REVIEW_COLUMN_ID="your_review_column_id" # Remplacez par l'ID de la colonne "review"
+          
+          # Obtenez l'ID de la carte de l'issue
+          CARD_ID=$(gh api graphql -f query='
+            query($issue: ID!) {
+              node(id: $issue) {
+                ... on Issue {
+                  projectCards(first: 1) {
+                    nodes {
+                      id
+                      column {
+                        id
+                      }
+                    }
+                  }
+                }
+              }
+            }' -f issue="MDU6SXNzdWU=$ISSUE_NUMBER" --jq '.data.node.projectCards.nodes[0].id')
+
+          if [ -z "$CARD_ID" ]; then
+            echo "No project card found for issue #$ISSUE_NUMBER."
+            exit 1
+          fi
+
+          # Vérifiez si la carte est dans la colonne "review"
+          COLUMN_ID=$(gh api graphql -f query='
+            query($card: ID!) {
+              node(id: $card) {
+                ... on ProjectCard {
+                  column {
+                    id
+                  }
+                }
+              }
+            }' -f card="$CARD_ID" --jq '.data.node.column.id')
+
+          if [ "$COLUMN_ID" != "$REVIEW_COLUMN_ID" ]; then
+            echo "Issue #$ISSUE_NUMBER is not in the review column."
+            exit 1
+          fi
+
+  move-issue:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    needs: check-issue
+    steps:
+      - name: Move issue to done column
+        run: |
+          ISSUE_NUMBER=${{ needs.check-issue.outputs.issue_number }}
+          DONE_COLUMN_ID="your_done_column_id" # Remplacez par l'ID de la colonne "done"
+          
+          # Déplacez la carte de l'issue dans la colonne "done"
+          gh api graphql -f query='
+            mutation($cardId: ID!, $columnId: ID!) {
+              moveProjectCard(input: {cardId: $cardId, columnId: $columnId}) {
+                clientMutationId
+              }
+            }' -f cardId="$CARD_ID" -f columnId="$DONE_COLUMN_ID"
+
+      - name: Approve PR
+        if: success()
+        run: echo "Pull request can be merged."

--- a/.github/workflows/prevent-merge.yml
+++ b/.github/workflows/prevent-merge.yml
@@ -23,8 +23,8 @@ jobs:
         id: check_review
         run: |
           ISSUE_NUMBER=${{ steps.check_issue.outputs.issue_number }}
-          PROJECT_ID="your_project_id" # Remplacez par l'ID de votre projet
-          REVIEW_COLUMN_ID="your_review_column_id" # Remplacez par l'ID de la colonne "review"
+          PROJECT_ID="1" # Remplacez par l'ID de votre projet
+          REVIEW_COLUMN_ID="5" # Remplacez par l'ID de la colonne "review"
           
           # Obtenez l'ID de la carte de l'issue
           CARD_ID=$(gh api graphql -f query='
@@ -73,7 +73,7 @@ jobs:
       - name: Move issue to done column
         run: |
           ISSUE_NUMBER=${{ needs.check-issue.outputs.issue_number }}
-          DONE_COLUMN_ID="your_done_column_id" # Remplacez par l'ID de la colonne "done"
+          DONE_COLUMN_ID="6" # Remplacez par l'ID de la colonne "done"
           
           # Déplacez la carte de l'issue dans la colonne "done"
           gh api graphql -f query='


### PR DESCRIPTION
# 📝 Titre de la Pull Request
Ajout d'un workflow pour empêcher le merge des pull requests sans issue associée et déplacer l'issue dans la colonne "done" après le merge

## 📌 Description
Cette PR introduit un nouveau workflow GitHub dans le fichier `.github/workflows/prevent-merge.yml`. Ce workflow a pour but de garantir que les pull requests ne peuvent être mergées que si elles sont associées à une issue et que cette issue se trouve dans la colonne "review" d'un projet. De plus, lorsque la pull request est mergée, l'issue associée est déplacée dans la colonne "done".

## ✅ Modifications apportées
1. **Vérification de l'issue associée** :
   - Ajout d'une étape pour extraire le numéro de l'issue de la description de la pull request.
   - Si aucun numéro d'issue n'est trouvé, le merge est empêché.

2. **Vérification de la colonne "review"** :
   - Ajout d'une étape pour vérifier si l'issue est dans la colonne "review" du projet.
   - Si l'issue n'est pas dans la colonne "review", le merge est également empêché.

3. **Déplacement de l'issue après le merge** :
   - Ajout d'une étape qui se déclenche uniquement si la pull request est mergée.
   - Cette étape déplace l'issue associée dans la colonne "done" du projet.

4. **Configuration des IDs de projet et de colonnes** :
   - Les IDs de projet et de colonnes sont configurés dans le fichier :
     - `PROJECT_ID` : ID du projet (actuellement défini sur `1`).
     - `REVIEW_COLUMN_ID` : ID de la colonne "review" (actuellement défini sur `5`).
     - `DONE_COLUMN_ID` : ID de la colonne "done" (actuellement défini sur `6`).

## 💡 Pourquoi ces changements ?
Ces modifications visent à améliorer la gestion des pull requests et des issues dans notre projet. En s'assurant que chaque pull request est liée à une issue dans la colonne "review", nous facilitons le suivi des tâches et maintenons une organisation claire des issues. Le déplacement automatique des issues dans la colonne "done" après le merge permet également de garder une vue d'ensemble sur l'avancement des tâches.

## 🔗 Liens associés
- Fichier modifié : `.github/workflows/prevent-merge.yml`