### PR TITLE
chore: add logger to catch logs to a file

### DIFF
--- a/front/.env.example
+++ b/front/.env.example
@@ -16,3 +16,6 @@ SOLANA_RPC_ENDPOINT=
 
 # Active l'enregistrement des logs de la console dans un fichier dans logs/logs.txt si égale -> true
 NEXT_PUBLIC_ENABLE_FILE_LOGGING=true
+
+# Active l'affichage des logs dans la console si égale -> true
+NEXT_PUBLIC_ENABLE_SCREEN_LOGGING=true 

--- a/front/.env.example
+++ b/front/.env.example
@@ -13,3 +13,6 @@ ADMIN_SEED_BASE64=
 
 #URL du nœud RPC Solana
 SOLANA_RPC_ENDPOINT=
+
+# Active l'enregistrement des logs de la console dans un fichier dans logs/logs.txt si égale -> true
+NEXT_PUBLIC_ENABLE_FILE_LOGGING=true

--- a/front/app/[locale]/layout.tsx
+++ b/front/app/[locale]/layout.tsx
@@ -1,10 +1,10 @@
-import "../globals.css";
 import { AltSidebar } from "@/components/layout/AltSidebar";
 import Footer from "@/components/layout/Footer";
 import Header from "@/components/layout/Header";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import AppWalletProvider from "@/components/wallet/AppWalletProvider";
 import { ProgramProvider } from "@/context/ProgramContext";
+import "@/utils/logger";
 import type { Metadata } from "next";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
@@ -14,6 +14,7 @@ import localFont from "next/font/local";
 import { cookies } from "next/headers";
 import { notFound } from "next/navigation";
 import { Toaster } from "sonner";
+import "../globals.css";
 import { routing } from "../i18n/routing";
 
 const inter = Inter({

--- a/front/utils/logger.ts
+++ b/front/utils/logger.ts
@@ -8,6 +8,8 @@ const originalStdoutWrite = process.stdout.write;
 // Configuration des logs
 const ENABLE_FILE_LOGGING =
   process.env.NEXT_PUBLIC_ENABLE_FILE_LOGGING === "true";
+const ENABLE_SCREEN_LOGGING =
+  process.env.NEXT_PUBLIC_ENABLE_SCREEN_LOGGING === "true"; // false par défaut
 
 // Chemin du dossier et du fichier de logs
 const logsDir = path.join(process.cwd(), "logs");
@@ -106,10 +108,14 @@ console.log = (...args: any[]) => {
       .join(" ");
 
     // Écriture dans le fichier si activé
-    writeToLog(message);
+    if (ENABLE_FILE_LOGGING) {
+      writeToLog(message);
+    }
 
-    // Toujours afficher dans la console
-    originalConsoleLog.apply(console, args);
+    // Affichage console si activé
+    if (ENABLE_SCREEN_LOGGING) {
+      originalConsoleLog.apply(console, args);
+    }
   } catch (error) {
     originalConsoleLog("Error writing to log file:", error);
   }
@@ -120,10 +126,15 @@ process.stdout.write = function (chunk: any) {
   try {
     const message = chunk.toString().trim();
     if (message) {
-      writeToLog(message);
+      if (ENABLE_FILE_LOGGING) {
+        writeToLog(message);
+      }
+      if (ENABLE_SCREEN_LOGGING) {
+        return originalStdoutWrite.apply(process.stdout, arguments as any);
+      }
     }
   } catch (error) {
     originalConsoleLog("Error writing stdout to log file:", error);
   }
-  return originalStdoutWrite.apply(process.stdout, arguments as any);
+  return true; // Pour éviter les erreurs quand ENABLE_SCREEN_LOGGING est false
 };

--- a/front/utils/logger.ts
+++ b/front/utils/logger.ts
@@ -1,0 +1,129 @@
+import fs from "fs";
+import path from "path";
+
+// Sauvegarde des fonctions originales
+const originalConsoleLog = console.log;
+const originalStdoutWrite = process.stdout.write;
+
+// Configuration des logs
+const ENABLE_FILE_LOGGING =
+  process.env.NEXT_PUBLIC_ENABLE_FILE_LOGGING === "true";
+
+// Chemin du dossier et du fichier de logs
+const logsDir = path.join(process.cwd(), "logs");
+const logFilePath = path.join(logsDir, "logs.txt");
+
+// Créer le dossier logs si nécessaire et si les logs fichier sont activés
+if (ENABLE_FILE_LOGGING) {
+  try {
+    if (!fs.existsSync(logsDir)) {
+      fs.mkdirSync(logsDir, { recursive: true });
+    }
+  } catch (error) {
+    originalConsoleLog("Error creating logs directory:", error);
+  }
+}
+
+// Variable pour stocker le dernier message
+let lastMessage = "";
+let lastTimestamp = 0;
+const DUPLICATE_TIMEOUT = 1000; // 1 seconde entre les messages identiques
+
+// Fonction pour ajouter un timestamp aux logs en format français
+const getTimestamp = () => {
+  const date = new Date();
+  return date.toLocaleString("fr-FR", {
+    timeZone: "Europe/Paris",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    fractionalSecondDigits: 3,
+  });
+};
+
+// Fonction pour nettoyer les codes ANSI et autres formatages
+const cleanMessage = (str: string): string => {
+  return (
+    str
+      // Nettoie les codes ANSI (couleurs, styles, etc.)
+      .replace(/\u001b\[\d+m|\u001b\[\d+;\d+m|\u001b\[\d+;\d+;\d+m/g, "")
+      // Nettoie les codes de couleur [32m etc.
+      .replace(/\[\d+m/g, "")
+      // Enlève les guillemets simples colorés
+      .replace(/\[32m'|'\[39m/g, "'")
+      // Nettoie les espaces multiples
+      .replace(/\s+/g, " ")
+      // Nettoie les espaces en début et fin
+      .trim()
+  );
+};
+
+// Fonction pour normaliser un message pour la comparaison
+const normalizeMessage = (message: string): string => {
+  return (
+    cleanMessage(message)
+      // Enlève les timestamps variables
+      .replace(/\d+ms|\d+\.\d+s/g, "")
+      // Enlève les adresses variables
+      .replace(/0x[a-fA-F0-9]+/g, "")
+      // Enlève les nombres variables
+      .replace(/\d+/g, "")
+  );
+};
+
+// Fonction pour écrire dans le fichier de log
+const writeToLog = (message: string) => {
+  if (!ENABLE_FILE_LOGGING) return;
+
+  const now = Date.now();
+  const normalizedMessage = normalizeMessage(message);
+
+  if (
+    normalizedMessage === lastMessage &&
+    now - lastTimestamp < DUPLICATE_TIMEOUT
+  ) {
+    return;
+  }
+
+  lastMessage = normalizedMessage;
+  lastTimestamp = now;
+
+  const cleanedMessage = cleanMessage(message);
+  const logMessage = `[${getTimestamp()}] ${cleanedMessage}\n`;
+  fs.appendFileSync(logFilePath, logMessage);
+};
+
+// Surcharge de console.log
+console.log = (...args: any[]) => {
+  try {
+    const message = args
+      .map((arg) =>
+        typeof arg === "object" ? JSON.stringify(arg, null, 2) : String(arg)
+      )
+      .join(" ");
+
+    // Écriture dans le fichier si activé
+    writeToLog(message);
+
+    // Toujours afficher dans la console
+    originalConsoleLog.apply(console, args);
+  } catch (error) {
+    originalConsoleLog("Error writing to log file:", error);
+  }
+};
+
+// Surcharge de stdout.write pour les logs de Next.js
+process.stdout.write = function (chunk: any) {
+  try {
+    const message = chunk.toString().trim();
+    if (message) {
+      writeToLog(message);
+    }
+  } catch (error) {
+    originalConsoleLog("Error writing stdout to log file:", error);
+  }
+  return originalStdoutWrite.apply(process.stdout, arguments as any);
+};


### PR DESCRIPTION
## Description

Implémentation d'un système de logging qui redirige les sorties de `console.log` vers un fichier tout en conservant l'affichage dans la console.

### Problème
Dans le cadre du développement et du débogage, il est nécessaire de conserver un historique des logs pour une analyse ultérieure. Actuellement, les logs sont uniquement affichés dans la console.

### Solution
- Surcharge de `console.log` pour écrire dans un fichier
- Nettoyage des codes ANSI et formatage des messages
- Gestion des doublons avec timestamp
- Contrôle via variable d'environnement `NEXT_PUBLIC_ENABLE_FILE_LOGGING`

## Changements

- ✨ Nouveau fichier `front/utils/logger.ts`
- 🔧 Modification de `front/app/[locale]/layout.tsx` pour importer le logger
- 📝 Les logs sont écrits dans `front/logs/logs.txt`

## Tests

- [x] Vérification de l'écriture des logs dans le fichier
- [x] Vérification du formatage (timestamps, nettoyage ANSI)
- [x] Test de la déduplication des messages
- [x] Test de la variable d'environnement

## Configuration

Ajouter dans le `.env` : `NEXT_PUBLIC_ENABLE_FILE_LOGGING=true`

---

### 📌 Lié à

- Issue : #167 

---

## 👥 Revue

- **Relecteurs suggérés** : @pylejeune @AlexLakarm  

---

## Screenshots

<img width="548" alt="image" src="https://github.com/user-attachments/assets/be83b5f8-e776-42a6-bc98-1b94380a4c8e" />

Closes #167