### PR TITLE
195 chore ajout require programconfig aux instructions automatisees

### DIFF
--- a/programs/programs/programs/src/instructions/end_epoch.rs
+++ b/programs/programs/programs/src/instructions/end_epoch.rs
@@ -1,35 +1,33 @@
 use anchor_lang::prelude::*;
 
-use crate::state::*;
-
+use crate::state::{EpochManagement, EpochStatus, ProgramConfig};
 use crate::error::ErrorCode;
 
 pub fn handler(ctx: Context<EndEpoch>, epoch_id: u64) -> Result<()> {
-    // Vérifier que l'époque existe
+    require!(
+        ctx.accounts.authority.key() == ctx.accounts.program_config.admin_authority,
+        ErrorCode::Unauthorized
+    );
+
     let epoch = &mut ctx.accounts.epoch_management;
     
-    // Vérifier que l'ID de l'époque correspond
     require!(
         epoch.epoch_id == epoch_id,
         ErrorCode::InvalidEpochId
     );
     
-    // Vérifier que l'époque est actuellement active
     require!(
         matches!(epoch.status, EpochStatus::Active),
         ErrorCode::EpochAlreadyInactive
     );
     
-    // Récupérer l'heure actuelle
     let current_time = Clock::get()?.unix_timestamp;
     
-    // Mettre à jour le statut de l'époque à inactive et la date de fin
     epoch.status = EpochStatus::Closed;
     epoch.end_time = current_time;
 
     println!("Epoch: {:?}", epoch.status);
     
-    // Émettre un événement pour la clôture de l'époque
     emit!(EpochEnded {
         epoch_id,
         ended_at: current_time,
@@ -41,6 +39,12 @@ pub fn handler(ctx: Context<EndEpoch>, epoch_id: u64) -> Result<()> {
 #[derive(Accounts)]
 #[instruction(epoch_id: u64)]
 pub struct EndEpoch<'info> {
+    #[account(
+        seeds = [b"config"],
+        bump
+    )]
+    pub program_config: Account<'info, ProgramConfig>,
+
     #[account(
         mut,
         seeds = [b"epoch", epoch_id.to_le_bytes().as_ref()],

--- a/programs/programs/programs/src/instructions/update_proposal_status.rs
+++ b/programs/programs/programs/src/instructions/update_proposal_status.rs
@@ -7,7 +7,6 @@ use crate::error::ErrorCode;
 #[derive(Accounts)]
 pub struct UpdateProposalStatus<'info> {
     // L'autorité doit signer et correspondre à l'autorité configurée dans ProgramConfig
-    #[account(constraint = authority.key() == program_config.admin_authority @ ErrorCode::InvalidAuthority)]
     pub authority: Signer<'info>,
     // Le compte contenant la configuration globale (et l'autorité admin)
     pub program_config: Account<'info, ProgramConfig>,
@@ -31,6 +30,12 @@ pub struct UpdateProposalStatus<'info> {
 }
 
 pub fn handler(ctx: Context<UpdateProposalStatus>, new_status: ProposalStatus) -> Result<()> {
+    // Modification: Ajout de la vérification d'autorité ici
+    require!(
+        ctx.accounts.authority.key() == ctx.accounts.program_config.admin_authority,
+        ErrorCode::Unauthorized
+    );
+
     // Vérifier que la proposition est actuellement active avant de la finaliser
     require!(ctx.accounts.proposal.status == ProposalStatus::Active, ErrorCode::ProposalAlreadyFinalized);
 

--- a/programs/tests/epoch_scheduler.test.ts
+++ b/programs/tests/epoch_scheduler.test.ts
@@ -5,11 +5,58 @@ import { Programs } from "../target/types/programs";
 import { BN } from "@coral-xyz/anchor";
 import { expect } from "chai";
 
+// Seed fixe pour l'autorité admin des tests (COHÉRENT AVEC LES AUTRES FICHIERS)
+const ADMIN_SEED = Uint8Array.from([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32]);
+
 describe("epoch_scheduler", () => {
   const provider = anchor.AnchorProvider.env();
   anchor.setProvider(provider);
 
   const program = anchor.workspace.Programs as Program<Programs>;
+  let adminAuthority: Keypair; // MODIFIÉ: Sera Keypair.fromSeed(ADMIN_SEED)
+  let programConfigPda: PublicKey;
+
+  before(async () => {
+    adminAuthority = Keypair.fromSeed(ADMIN_SEED); // MODIFIÉ: Utiliser la seed
+    const connection = provider.connection;
+
+    // Financer adminAuthority si nécessaire
+    const adminInfo = await connection.getAccountInfo(adminAuthority.publicKey);
+    if (!adminInfo || adminInfo.lamports < 2 * anchor.web3.LAMPORTS_PER_SOL) {
+      const sig = await connection.requestAirdrop(adminAuthority.publicKey, 2 * anchor.web3.LAMPORTS_PER_SOL);
+      await connection.confirmTransaction(sig, "confirmed");
+      console.log(`Admin authority ${adminAuthority.publicKey.toBase58()} (from seed) funded in epoch_scheduler.`);
+    } else {
+      console.log(`Admin authority ${adminAuthority.publicKey.toBase58()} (from seed) already funded in epoch_scheduler.`);
+    }
+
+    // Dériver le PDA pour ProgramConfig
+    [programConfigPda] = PublicKey.findProgramAddressSync(
+      [Buffer.from("config")],
+      program.programId
+    );
+
+    // Initialiser ProgramConfig (gestion de l'initialisation multiple)
+    try {
+      await program.methods
+        .initializeProgramConfig(adminAuthority.publicKey)
+        .accounts({
+          programConfig: programConfigPda,
+          authority: adminAuthority.publicKey,
+          systemProgram: anchor.web3.SystemProgram.programId,
+        } as any)
+        .signers([adminAuthority]) // MODIFIÉ: adminAuthority (Keypair) est le signataire
+        .rpc();
+      console.log("ProgramConfig initialized in epoch_scheduler.test.ts");
+    } catch (error) {
+      const errorString = (error as Error).toString();
+      if (errorString.includes("already in use") || errorString.includes("custom program error: 0x0")) {
+        console.log("ProgramConfig already initialized in epoch_scheduler.test.ts.");
+      } else {
+        throw error;
+      }
+    }
+  });
 
   it("Vérifie et ferme les époques actives", async () => {
     // Créer une nouvelle époque pour le test
@@ -27,10 +74,12 @@ describe("epoch_scheduler", () => {
     await program.methods
       .startEpoch(epochId, startTime, endTime)
       .accounts({
-        authority: provider.wallet.publicKey,
+        authority: adminAuthority.publicKey, // Utiliser adminAuthority.publicKey
+        programConfig: programConfigPda,
         epochManagement: epochManagementPDA,
         systemProgram: anchor.web3.SystemProgram.programId,
       } as any)
+      .signers([adminAuthority]) // MODIFIÉ: adminAuthority (Keypair) est le signataire
       .rpc();
 
     // Vérifier que l'époque est active
@@ -41,10 +90,12 @@ describe("epoch_scheduler", () => {
     await program.methods
       .endEpoch(epochId)
       .accounts({
+        authority: adminAuthority.publicKey, // Utiliser adminAuthority.publicKey
+        programConfig: programConfigPda,
         epochManagement: epochManagementPDA,
-        authority: provider.wallet.publicKey,
         systemProgram: anchor.web3.SystemProgram.programId,
       } as any)
+      .signers([adminAuthority]) // MODIFIÉ: adminAuthority (Keypair) est le signataire
       .rpc();
 
     // Vérifier que l'époque est maintenant fermée

--- a/programs/tests/epoch_scheduler.test.ts
+++ b/programs/tests/epoch_scheduler.test.ts
@@ -30,7 +30,7 @@ describe("epoch_scheduler", () => {
         authority: provider.wallet.publicKey,
         epochManagement: epochManagementPDA,
         systemProgram: anchor.web3.SystemProgram.programId,
-      })
+      } as any)
       .rpc();
 
     // Vérifier que l'époque est active
@@ -44,7 +44,7 @@ describe("epoch_scheduler", () => {
         epochManagement: epochManagementPDA,
         authority: provider.wallet.publicKey,
         systemProgram: anchor.web3.SystemProgram.programId,
-      })
+      } as any)
       .rpc();
 
     // Vérifier que l'époque est maintenant fermée

--- a/programs/tests/programconfig.test.ts
+++ b/programs/tests/programconfig.test.ts
@@ -1,25 +1,9 @@
 import * as anchor from "@coral-xyz/anchor";
-import { Program, web3 } from "@coral-xyz/anchor";
+// import { Program, web3 } from "@coral-xyz/anchor"; // Supprimer cette ligne
 import { Keypair, PublicKey, SystemProgram } from "@solana/web3.js";
 import { expect } from "chai";
 // epochStatus n'est pas exporté directement, nous accédons aux statuts via les clés de l'objet.
 import { Programs } from "../target/types/programs"; 
-
-// TODO: Importer ou définir les fonctions de setup nécessaires :
-// import {
-//   initializeTestContext,
-//   ensureProgramConfigInitialized,
-//   // ... autres fonctions de setup (epoch, proposal)
-// } from "./setup"; // Adaptez le chemin vers vos utilitaires de setup
-
-// TODO: Définir un type pour le contexte de test si vous en utilisez un unifié
-// interface TestContext { 
-//   provider: anchor.AnchorProvider;
-//   program: Program<Programs>;
-//   adminKeypair: Keypair;
-//   programConfigAddress: PublicKey;
-//   // ... autres éléments utiles
-// }
 
 // Seed fixe pour l'autorité admin des tests (COHÉRENT AVEC LES AUTRES FICHIERS)
 const ADMIN_SEED = Uint8Array.from([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32]);
@@ -100,7 +84,7 @@ describe("ProgramConfig - Admin Only Instructions Authorization", () => {
          console.log(`Confirmed admin authority in ProgramConfig for programconfig.test.ts: ${configAccount.adminAuthority.toBase58()}`);
     });
 
-    describe("start_epoch", () => {
+    describe("Instruction start_epoch : ProgramConfig authorization", () => {
         const now = Date.now();
         const epochId = new anchor.BN(now); 
         const startTime = new anchor.BN(Math.floor(now / 1000));
@@ -147,15 +131,15 @@ describe("ProgramConfig - Admin Only Instructions Authorization", () => {
                     .rpc();
                 expect.fail("Transaction should have failed with Unauthorized error");
             } catch (error) {
-                expect((error as AnchorError).error.errorCode.code).to.equal("Unauthorized");
-                expect((error as AnchorError).error.errorCode.number).to.equal(6023);
+                expect((error as anchor.AnchorError).error.errorCode.code).to.equal("Unauthorized");
+                expect((error as anchor.AnchorError).error.errorCode.number).to.equal(6023);
             }
         });
 
    
     });
 
-    describe("end_epoch", () => {
+    describe("Instruction end_epoch : ProgramConfig authorization", () => {
         let testEpochId: anchor.BN;
         let epochManagementAddress: PublicKey;
 
@@ -214,13 +198,13 @@ describe("ProgramConfig - Admin Only Instructions Authorization", () => {
                     .rpc();
                 expect.fail("Transaction should have failed with Unauthorized error");
             } catch (error) {
-                expect((error as AnchorError).error.errorCode.code).to.equal("Unauthorized");
-                expect((error as AnchorError).error.errorCode.number).to.equal(6023);
+                expect((error as anchor.AnchorError).error.errorCode.code).to.equal("Unauthorized");
+                expect((error as anchor.AnchorError).error.errorCode.number).to.equal(6023);
             }
         });
     });
 
-    describe("update_proposal_status", () => {
+    describe("Instruction update_proposal_status : ProgramConfig authorization", () => {
         let testEpochId: anchor.BN;
         let epochManagementAddress: PublicKey;
         let proposalCreator: Keypair; // Peut être adminKeypair ou un autre
@@ -319,13 +303,13 @@ describe("ProgramConfig - Admin Only Instructions Authorization", () => {
                     .rpc();
                 expect.fail("Transaction should have failed with Unauthorized error");
             } catch (error) {
-                expect((error as AnchorError).error.errorCode.code).to.equal("Unauthorized");
-                expect((error as AnchorError).error.errorCode.number).to.equal(6023);
+                expect((error as anchor.AnchorError).error.errorCode.code).to.equal("Unauthorized");
+                expect((error as anchor.AnchorError).error.errorCode.number).to.equal(6023);
             }
         });
     });
     
-    describe("mark_epoch_processed", () => {
+    describe("Instruction mark_epoch_processed : ProgramConfig authorization", () => {
         let testEpochId: anchor.BN;
         let epochManagementAddress: PublicKey;
 
@@ -396,22 +380,9 @@ describe("ProgramConfig - Admin Only Instructions Authorization", () => {
                     .rpc();
                 expect.fail("Transaction should have failed with Unauthorized error");
             } catch (error) {
-                expect((error as AnchorError).error.errorCode.code).to.equal("Unauthorized");
-                expect((error as AnchorError).error.errorCode.number).to.equal(6023);
+                expect((error as anchor.AnchorError).error.errorCode.code).to.equal("Unauthorized");
+                expect((error as anchor.AnchorError).error.errorCode.number).to.equal(6023);
             }
         });
     });
 });
-
-// Définition du type AnchorError pour un meilleur typage des erreurs
-interface AnchorError extends Error {
-    error: {
-        errorCode: {
-            code: string; // ex: "Unauthorized"
-            number: number; // ex: 6023
-        };
-        errorMessage: string;
-        // ... autres propriétés possibles
-    };
-    // ... autres propriétés possibles
-} 

--- a/programs/tests/programconfig.test.ts
+++ b/programs/tests/programconfig.test.ts
@@ -1,0 +1,220 @@
+import * as anchor from "@coral-xyz/anchor";
+import { Program, web3 } from "@coral-xyz/anchor";
+import { Keypair, PublicKey, SystemProgram } from "@solana/web3.js";
+import { expect } from "chai";
+// epochStatus n'est pas exporté directement, nous accédons aux statuts via les clés de l'objet.
+import { Programs } from "../target/types/programs"; 
+
+// TODO: Importer ou définir les fonctions de setup nécessaires :
+// import {
+//   initializeTestContext,
+//   ensureProgramConfigInitialized,
+//   // ... autres fonctions de setup (epoch, proposal)
+// } from "./setup"; // Adaptez le chemin vers vos utilitaires de setup
+
+// TODO: Définir un type pour le contexte de test si vous en utilisez un unifié
+// interface TestContext { 
+//   provider: anchor.AnchorProvider;
+//   program: Program<Programs>;
+//   adminKeypair: Keypair;
+//   programConfigAddress: PublicKey;
+//   // ... autres éléments utiles
+// }
+
+const getProgramConfigPda = (programId: PublicKey): [PublicKey, number] => {
+    return PublicKey.findProgramAddressSync(
+        [Buffer.from("config")],
+        programId
+    );
+};
+
+
+describe("ProgramConfig - Admin Only Instructions Authorization", () => {
+    const provider = anchor.AnchorProvider.env();
+    anchor.setProvider(provider);
+    // Tentative sans cast explicite pour voir si cela aide le linter
+    const program = anchor.workspace.Programs;
+    let adminKeypair: Keypair;
+    let nonAdminKeypair: Keypair;
+    let programConfigAddress: PublicKey;
+
+    before(async () => {
+        // Créer et financer adminKeypair explicitement
+        adminKeypair = Keypair.generate();
+        nonAdminKeypair = Keypair.generate();
+        const connection = provider.connection;
+
+        // Airdrop pour adminKeypair
+        const adminAirdropSignature = await connection.requestAirdrop(
+            adminKeypair.publicKey,
+            2 * anchor.web3.LAMPORTS_PER_SOL // Un peu plus pour être sûr
+        );
+        await connection.confirmTransaction(adminAirdropSignature, "confirmed");
+
+        // Airdrop pour nonAdminKeypair
+        const nonAdminAirdropSignature = await connection.requestAirdrop(
+            nonAdminKeypair.publicKey,
+            1 * anchor.web3.LAMPORTS_PER_SOL
+        );
+        await connection.confirmTransaction(nonAdminAirdropSignature, "confirmed");
+        
+        [programConfigAddress] = getProgramConfigPda(program.programId);
+
+        try {
+            await program.methods
+                .initializeProgramConfig(adminKeypair.publicKey) 
+                .accounts({
+                    programConfig: programConfigAddress,
+                    authority: adminKeypair.publicKey,
+                    systemProgram: SystemProgram.programId,
+                })
+                .signers([adminKeypair]) // adminKeypair signe l'initialisation
+                .rpc();
+            console.log("ProgramConfig initialized by admin.");
+        } catch (error) {
+            const errorString = (error as Error).toString();
+            if (errorString.includes("already in use") || 
+                errorString.includes("custom program error: 0x0") || 
+                errorString.includes("Program account already initialized")) {
+                 console.log("ProgramConfig already initialized or similar error.");
+            } else {
+                console.error("Error during ProgramConfig initialization:", error);
+                throw error;
+            }
+        }
+    });
+
+    describe("start_epoch", () => {
+        const now = Date.now();
+        const epochId = new anchor.BN(now); 
+        const startTime = new anchor.BN(Math.floor(now / 1000));
+        const endTime = new anchor.BN(Math.floor(now / 1000) + 3600);
+
+        const getEpochManagementPda = (currentEpochId: anchor.BN): [PublicKey, number] => {
+            return PublicKey.findProgramAddressSync(
+                [Buffer.from("epoch"), currentEpochId.toArrayLike(Buffer, "le", 8)],
+                program.programId
+            );
+        };
+
+        it("should allow admin_authority to call start_epoch", async () => {
+            const [epochManagementAddress] = getEpochManagementPda(epochId);
+            await program.methods
+                .startEpoch(epochId, startTime, endTime) 
+                .accounts({
+                    authority: adminKeypair.publicKey,
+                    programConfig: programConfigAddress,
+                    epochManagement: epochManagementAddress,
+                    systemProgram: SystemProgram.programId,
+                })
+                .signers([adminKeypair])
+                .rpc();
+            
+            const epochAccount = await program.account.epochManagement.fetch(epochManagementAddress);
+            expect(epochAccount.epochId.eq(epochId)).to.be.true;
+            expect(epochAccount.status.active).to.exist; 
+        });
+
+        it("should prevent non_admin_authority from calling start_epoch and return Unauthorized error", async () => {
+            const currentEpochId = new anchor.BN(epochId.toNumber() + 1);
+            const [epochManagementAddress] = getEpochManagementPda(currentEpochId);
+            try {
+                await program.methods
+                    .startEpoch(currentEpochId, startTime, endTime) 
+                    .accounts({
+                        authority: nonAdminKeypair.publicKey,
+                        programConfig: programConfigAddress,
+                        epochManagement: epochManagementAddress,
+                        systemProgram: SystemProgram.programId,
+                    })
+                    .signers([nonAdminKeypair])
+                    .rpc();
+                expect.fail("Transaction should have failed with Unauthorized error");
+            } catch (error) {
+                expect((error as AnchorError).error.errorCode.code).to.equal("Unauthorized");
+                expect((error as AnchorError).error.errorCode.number).to.equal(6023);
+            }
+        });
+
+        it("should successfully start an epoch when called by admin_authority", async () => {
+            const newEpochId = new anchor.BN(epochId.toNumber() + 2);
+            const [epochManagementAddress] = getEpochManagementPda(newEpochId);
+            await program.methods
+                .startEpoch(newEpochId, startTime, endTime)
+                .accounts({
+                    authority: adminKeypair.publicKey,
+                    programConfig: programConfigAddress,
+                    epochManagement: epochManagementAddress,
+                    systemProgram: SystemProgram.programId,
+                })
+                .signers([adminKeypair])
+                .rpc();
+            
+            const epochAccount = await program.account.epochManagement.fetch(epochManagementAddress);
+            expect(epochAccount.epochId.eq(newEpochId)).to.be.true;
+            expect(epochAccount.status.active).to.exist;
+            console.log(`Epoch ${newEpochId.toString()} started successfully by admin.`);
+        });
+    });
+
+    describe("end_epoch", () => {
+        // Pré-requis: un epoch doit être démarré
+        // TODO: Ajouter un before() ou un setup pour démarrer un epoch spécifique pour ces tests
+        it("should allow admin_authority to call end_epoch", async () => {
+            // TODO: Implémentation
+        });
+
+        it("should prevent non_admin_authority from calling end_epoch and return Unauthorized error", async () => {
+            // TODO: Implémentation
+        });
+
+        it("should successfully end an epoch when called by admin_authority", async () => {
+            // TODO: Implémentation
+        });
+    });
+
+    describe("update_proposal_status", () => {
+        // Pré-requis: un epoch doit être fermé, une proposition doit exister dans cet epoch
+        // TODO: Ajouter setup
+        it("should allow admin_authority to call update_proposal_status", async () => {
+            // TODO: Implémentation
+        });
+
+        it("should prevent non_admin_authority from calling update_proposal_status and return Unauthorized error", async () => {
+            // TODO: Implémentation
+        });
+
+        it("should successfully update proposal status when called by admin_authority", async () => {
+            // TODO: Implémentation
+        });
+    });
+    
+    describe("mark_epoch_processed", () => {
+        // Pré-requis: un epoch doit être fermé (ou dans un état approprié pour être marqué comme traité)
+        // TODO: Ajouter setup
+        it("should allow admin_authority to call mark_epoch_processed", async () => {
+            // TODO: Implémentation
+        });
+
+        it("should prevent non_admin_authority from calling mark_epoch_processed and return Unauthorized error", async () => {
+            // TODO: Implémentation
+        });
+
+        it("should successfully mark an epoch as processed when called by admin_authority", async () => {
+            // TODO: Implémentation
+        });
+    });
+});
+
+// Définition du type AnchorError pour un meilleur typage des erreurs
+interface AnchorError extends Error {
+    error: {
+        errorCode: {
+            code: string; // ex: "Unauthorized"
+            number: number; // ex: 6023
+        };
+        errorMessage: string;
+        // ... autres propriétés possibles
+    };
+    // ... autres propriétés possibles
+} 

--- a/programs/tests/treasury_roles.test.ts
+++ b/programs/tests/treasury_roles.test.ts
@@ -22,7 +22,7 @@ describe('TreasuryRoles (multi-admin & roles management)', () => {
     provider = anchor.AnchorProvider.env();
     anchor.setProvider(provider);
     // program = anchor.workspace.NorugFun as Program<NorugFun>; // À adapter
-    program = anchor.workspace.Programs as Program<Programs>;
+    program = anchor.workspace.Programs as Program<Programs>; 
     admin1 = Keypair.generate();
     admin2 = Keypair.generate();
     admin3 = Keypair.generate();
@@ -47,7 +47,7 @@ describe('TreasuryRoles (multi-admin & roles management)', () => {
         treasuryRoles: treasuryRolesPda,
         payer: admin1.publicKey,
         systemProgram: SystemProgram.programId,
-      })
+      } as any)
       .signers([admin1])
       .rpc();
     const acc = await program.account.treasuryRoles.fetch(treasuryRolesPda);


### PR DESCRIPTION
# ✨ Sécurisation des instructions lancées en automatiques par les cron grâce à programConfig et tests associés

## 📌 Description

-   **Contexte** : Cette PR vise à renforcer la sécurité de plusieurs instructions du programme Solana en s'assurant qu'elles ne peuvent être appelées que par une autorité administrative définie dans le compte de configuration global (`ProgramConfig`).
-   **Problème résolu** : Certaines instructions critiques pouvaient potentiellement être appelées par des entités non autorisées.
-   **Solution apportée** :
    *   Ajout d'une vérification `require!(ctx.accounts.authority.key() == ctx.accounts.program_config.admin_authority, ErrorCode::Unauthorized);` au début des handlers des instructions concernées.
    *   Mise à jour complète des tests existants pour refléter cette nouvelle exigence d'autorisation.
    *   Création d'un nouveau fichier de test `programconfig.test.ts` dédié à la vérification exhaustive des logiques d'autorisation pour les instructions administratives.

## ✅ Type de changement

-   [x] ✨ Nouvelle fonctionnalité (Contrôle d'accès basé sur `ProgramConfig`)
-   [x] 🔧 Refactoring (Mise à jour des tests existants)
-   [x] ✅ Ajout de tests (Nouveau fichier `programconfig.test.ts` et complétion des tests d'autorisation)
-   [x] 🔒 Amélioration de la sécurité

## 🔑 Modification principale du code (Rust)

La vérification suivante a été ajoutée aux instructions `start_epoch`, `end_epoch`, et `update_proposal_status` (l'instruction `mark_epoch_processed` avait déjà une vérification similaire qui a été uniformisée) :

```rust
require!(
    ctx.accounts.authority.key() == ctx.accounts.program_config.admin_authority,
    ErrorCode::Unauthorized
);
```

## 🧪 Tests ajoutés et mis à jour

### Fichier : `programs/tests/programconfig.test.ts`

Ce nouveau fichier de test s'assure que seules les autorités administratives peuvent appeler les instructions protégées et que les non-administrateurs reçoivent une erreur `Unauthorized`. Il vérifie également la fonctionnalité principale de chaque instruction lorsqu'elle est appelée par un administrateur.

**`Instruction: start_epoch - Authorization & Functionality`**
*   `should allow admin_authority to call start_epoch`
*   `should prevent non_admin_authority from calling start_epoch and return Unauthorized error`

**`Instruction: end_epoch - Authorization & Functionality`**
*   `should allow admin_authority to call end_epoch and successfully end an epoch`
*   `should prevent non_admin_authority from calling end_epoch and return Unauthorized error`

**`Instruction: update_proposal_status - Authorization & Functionality`**
*   `should allow admin_authority to call update_proposal_status and successfully update status`
*   `should prevent non_admin_authority from calling update_proposal_status and return Unauthorized error`

**`Instruction: mark_epoch_processed - Authorization & Functionality`**
*   `should allow admin_authority to call mark_epoch_processed and successfully mark epoch as processed`
*   `should prevent non_admin_authority from calling mark_epoch_processed and return Unauthorized error`

### Mises à jour des fichiers de test existants :

Les fichiers suivants ont été mis à jour pour inclure `programConfig` dans les comptes et utiliser `adminAuthority` (dérivé d'un seed déterministe) lors de l'appel des instructions désormais protégées (`startEpoch`, `endEpoch`, `updateProposalStatus`, `markEpochProcessed`) :

*   `programs/tests/crank_simulation.test.ts`
*   `programs/tests/epoch.test.ts`
*   `programs/tests/epoch_scheduler.test.ts`
*   `programs/tests/proposal.test.ts`
*   `programs/tests/reclaim.test.ts`
*   `programs/tests/updateproposal.test.ts`

Des contournements temporaires (`as any`) ont été appliqués dans `treasury_roles.test.ts` et `epoch_scheduler.test.ts` pour résoudre des problèmes de linter TypeScript persistants avec la résolution des types de comptes, afin de ne pas bloquer cette PR. Ces problèmes feront l'objet d'une investigation séparée.

## 🔍 Comment tester cette PR ?

1.  Checkout cette branche.
2.  Naviguer vers le répertoire `programs/`.
3.  Exécuter `anchor clean && anchor build`.
4.  Exécuter `anchor test`.
5.  **Résultats attendus** : Tous les tests (62/62) devraient passer, confirmant que les vérifications d'autorisation fonctionnent comme prévu et que les fonctionnalités principales des instructions ne sont pas rompues. Attention particulière à porter sur la partie programConfig :

<img width="687" alt="image" src="https://github.com/user-attachments/assets/34c8edaa-02c5-4d09-a7f2-6c7b93a4f36a" />

## 📎 Liens associés

-   **Issues liées** : #195 

## 👥 Revue

-   **Relecteurs suggérés** : @pylejeune @alexandre-bourdois 
-   **Domaines concernés** : `programs/src/instructions/`, `programs/tests/`

## 🧪 Checklist

-   [x] Le code compile sans erreur (`anchor build`)
-   [x] Les tests unitaires passent (`anchor test`)
-   [ ] La documentation est à jour (Non applicable pour cette PR)
-   [x] Les dépendances sont à jour
-   [x] La PR est prête pour la revue
