### PR TITLE
199 Add git hooks pre-commit and pre-push

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Aller dans le dossier front
+cd front
+
+# Vérifier le formatage et le linting des fichiers modifiés
+FILES=$(git diff --cached --name-only --diff-filter=ACMR "*.ts" "*.tsx" "*.js" "*.jsx" "*.json" "*.md" | sed 's| |\\ |g')
+[ -z "$FILES" ] && exit 0
+
+# Formater et linter les fichiers
+echo "🔍 Checking formatting and linting..."
+for FILE in $FILES; do
+  npm run format "$FILE"
+  npm run lint:fix "$FILE"
+done
+
+# Ajouter les fichiers modifiés au commit
+git add $FILES

--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -4,15 +4,16 @@
 cd front
 
 # Vérifier le formatage et le linting des fichiers modifiés
-FILES=$(git diff --cached --name-only --diff-filter=ACMR "*.ts" "*.tsx" "*.js" "*.jsx" "*.json" "*.md" | sed 's| |\\ |g')
+FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep -E "^front/.*\.(ts|tsx|js|jsx|json|md)$" | sed 's|^front/||')
 [ -z "$FILES" ] && exit 0
 
 # Formater et linter les fichiers
 echo "🔍 Checking formatting and linting..."
-for FILE in $FILES; do
-  npm run format "$FILE"
-  npm run lint:fix "$FILE"
-done
 
-# Ajouter les fichiers modifiés au commit
-git add $FILES
+# Formater tous les fichiers modifiés
+for FILE in $FILES; do
+  npx prettier --write "$FILE" --ignore-path .prettierignore
+  if echo "$FILE" | grep -E "\.(ts|tsx|js|jsx)$" >/dev/null; then
+    npx eslint --fix "$FILE"
+  fi
+done

--- a/.github/hooks/pre-push
+++ b/.github/hooks/pre-push
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Aller dans le dossier front
+cd front
+
+# Vérifier le linting
+echo "🔍 Checking linting..."
+
+npm run lint
+if [ $? -ne 0 ]; then
+  echo "❌ Lint check failed"
+  exit 1
+fi
+
+echo "✅ All checks passed"
+exit 0

--- a/front/package.json
+++ b/front/package.json
@@ -10,7 +10,8 @@
     "lint": "next lint",
     "lint:fix": "next lint --fix",
     "format": "npx prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\" --ignore-path .prettierignore",
-    "format:check": "npx prettier --check \"**/*.{ts,tsx,js,jsx,json,md}\" --ignore-path .prettierignore"
+    "format:check": "npx prettier --check \"**/*.{ts,tsx,js,jsx,json,md}\" --ignore-path .prettierignore",
+    "prepare": "rm -f ../.git/hooks/pre-commit ../.git/hooks/pre-push && cp ../.github/hooks/* ../.git/hooks/ && chmod +x ../.git/hooks/*"
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.30.1",


### PR DESCRIPTION
## 📌 Description

- **Contexte** : Dans le cadre de l'amélioration de la qualité du code (#192), nous ajoutons des hooks Git pour automatiser les vérifications.
- **Problème résolu** : Éviter les commits avec du code mal formaté et les pushs avec des erreurs de linting.
- **Solution apportée** : 
  - Ajout de hooks Git natifs dans `.github/hooks/` (versionnés avec le projet)
  - Configuration du script `prepare` dans `package.json` pour installation automatique
  - pre-commit : formate et lint automatiquement les fichiers modifiés
  - pre-push : vérifie le linting sur tout le projet

## ✅ Type de changement

- [x] 🔧 Ajout de Hooks git

## 🔍 Comment tester cette PR ?

Les hooks s'installent automatiquement avec `npm install` grâce au script `prepare` qui :
1. S'exécute après chaque `npm install`
2. Copie les hooks depuis `.github/hooks/` vers `.git/hooks/`
3. Les rend exécutables

Pour tester :
1. `cd front && npm install` (installe les hooks automatiquement)
2. Tester le pre-commit :
   - Modifier un fichier TypeScript
   - `git add` le fichier
   - `git commit` - le hook devrait formater le code
3. Tester le pre-push :
   - `git push` - le hook devrait vérifier le linting

## 📎 Liens associés

- **Issues liées** : 
  - #192
  - #199
- **Autres PRs** : 
  - #196 
  - #197
  - #198

## 👥 Revue

- **Domaines concernés** : Git hooks, Linting, Formatting

## 🧪 Checklist

- [x] Le code compile sans erreur
- [x] Les hooks sont testés localement
- [x] La documentation est à jour
- [x] La PR est prête pour la revue

## 🗒️ Notes complémentaires

- Les hooks sont versionnés dans `.github/hooks/` et copiés automatiquement dans `.git/hooks/`
- Le script `prepare` assure que tous les développeurs ont les mêmes hooks
- Les hooks peuvent être ignorés temporairement avec :
  - `git commit --no-verify`
  - `git push --no-verify`

Closes #199