### PR TITLE
242 [Fix] h-screen prb

### DIFF
--- a/front/app/[locale]/layout.tsx
+++ b/front/app/[locale]/layout.tsx
@@ -88,7 +88,7 @@ export default async function RootLayout({ children, params }: Props) {
             <AppWalletProvider>
               <ProgramProvider>
                 <SidebarProvider defaultOpen={defaultOpen}>
-                  <div className="flex h-screen w-full max-w-screen overflow-hidden">
+                  <div className="flex w-full max-w-screen overflow-hidden">
                     <AltSidebar />
                     <div className="flex-1 overflow-hidden">
                       <Header />


### PR DESCRIPTION
# 📝 Correction du problème de défilement dans le layout principal

## 📌 Description

- **Contexte** : Le layout principal utilisait `h-screen` qui forçait une hauteur fixe égale à la hauteur de l'écran.
- **Problème résolu** : Les utilisateurs ne pouvaient pas voir le contenu qui dépassait la hauteur de l'écran.
- **Solution apportée** : Suppression de `h-screen` tout en conservant les autres classes de gestion du défilement.

## ✅ Type de changement

- [x] 🐛 Correction de bug
- [ ] ✨ Nouvelle fonctionnalité
- [ ] 🔧 Refactoring
- [ ] 📝 Mise à jour de la documentation
- [ ] 🚀 Amélioration des performances
- [ ] ✅ Ajout de tests
- [ ] 🔒 Amélioration de la sécurité
- [ ] Autre (précisez) :

## 🔍 Comment tester cette PR ?

1. Ouvrir n'importe quelle page du site
2. Vérifier que le contenu défile correctement
3. S'assurer que tout le contenu est accessible, même celui qui dépasse la hauteur initiale de l'écran

## 📎 Liens associés

- **Issues liées** : #NuméroIssue (à remplir)
- **Documentation** : N/A
- **Autres PRs** : N/A

## 👥 Revue

- **Relecteurs suggérés** : @AlexLakarm et @pylejeune 
- **Domaines concernés** : 
  - Layout principal (`front/app/[locale]/layout.tsx`)

## 🧪 Checklist

- [x] Le code compile sans erreur
- [x] Les tests unitaires passent
- [x] La documentation est à jour
- [x] Les dépendances sont à jour
- [x] La PR est prête pour la revue

## 📸 Captures d'écran (si applicable)

N/A - Changement de comportement fonctionnel

## 🗒️ Notes complémentaires

Modification exacte :
```diff
- <div className="flex h-screen w-full max-w-screen overflow-hidden">
+ <div className="flex w-full max-w-screen overflow-hidden">
```

Cette modification supprime la contrainte de hauteur fixe (`h-screen`) tout en conservant les autres classes qui gèrent correctement le défilement et la largeur maximale.

(J'avais pas fait attention, je l'avais mis pour des tests avec la nouvelle bannière et j'ai oublié de le retirer au dernier moment)

