### PR TITLE
250 [chore] : Improve SloganBanner with i18n translations and UX fixes

### DIFF
--- a/front/components/home/SloganBanner.tsx
+++ b/front/components/home/SloganBanner.tsx
@@ -2,6 +2,7 @@
 
 import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
+import { useTranslations } from "next-intl";
 import Marquee from "react-fast-marquee";
 
 type Props = {
@@ -10,12 +11,7 @@ type Props = {
 
 export function SloganBanner({ className }: Props) {
   const isMobile = useIsMobile();
-
-  const textData = {
-    before: "10 tokens rise. The rest ",
-    highlight: "burn",
-    after: ". Choose your side.",
-  };
+  const t = useTranslations("SloganBanner");
 
   return (
     <div className={cn("w-full py-0 px-0", className)}>
@@ -24,7 +20,7 @@ export function SloganBanner({ className }: Props) {
           <Marquee
             gradient={false}
             speed={isMobile ? 30 : 50}
-            pauseOnHover={true}
+            pauseOnHover={false}
             style={{
               overflow: "hidden",
               width: "1200px",
@@ -39,11 +35,9 @@ export function SloganBanner({ className }: Props) {
                   : "text-4xl font-medium whitespace-nowrap text-white"
               }
             >
-              {textData.before}
-              <span className="text-red-600 font-bold">
-                {textData.highlight}
-              </span>
-              {textData.after}
+              {t("before")}
+              <span className="text-red-600 font-bold">{t("highlight")}</span>
+              {t("after")}
             </span>
           </Marquee>
         </div>

--- a/front/messages/en.json
+++ b/front/messages/en.json
@@ -7,6 +7,11 @@
     "title": "NoRug.fun",
     "message": "Loading"
   },
+  "SloganBanner": {
+    "before": "10 tokens rise. The rest ",
+    "highlight": "burn",
+    "after": ". Choose your side."
+  },
   "Footer": {
     "copyright": "© NoRug.fun {year}",
     "privacy": "privacy policy",

--- a/front/messages/fr.json
+++ b/front/messages/fr.json
@@ -7,6 +7,11 @@
     "title": "NoRug.fun",
     "message": "Chargement"
   },
+  "SloganBanner": {
+    "before": "10 tokens qualifiés. Le reste ",
+    "highlight": "brûle",
+    "after": ". Choisissez votre camp."
+  },
   "Footer": {
     "copyright": "© NoRug.fun {year}",
     "privacy": "politique de confidentialité",


### PR DESCRIPTION
## 📌 Description

- **Contexte** : Le slogan du marquee était hardcodé en anglais et le comportement pauseOnHover interrompait l'expérience utilisateur.
- **Problème résolu** : Manque de support multilingue et UX peu fluide du marquee.
- **Solution apportée** : Intégration de next-intl pour les traductions et désactivation du pauseOnHover pour un défilement continu.

## ✅ Type de changement

Cochez les options pertinentes :

- [ ] 🐛 Correction de bug
- [x] ✨ Nouvelle fonctionnalité
- [ ] 🔧 Refactoring
- [ ] 📝 Mise à jour de la documentation
- [x] 🚀 Amélioration des performances
- [ ] ✅ Ajout de tests
- [ ] 🔒 Amélioration de la sécurité
- [ ] Autre (précisez) :

## 🔍 Comment tester cette PR ?

Fournissez des instructions pour tester les modifications :

1. Aller sur la page d'accueil
2. Vérifier que le marquee défile en continu sans s'arrêter au survol
3. Changer la langue avec le LocaleSwitcher (EN/FR)
4. Vérifier que le slogan change de langue :
   - **EN** : "10 tokens rise. The rest burn. Choose your side."
   - **FR** : "10 tokens qualifiés. Le reste brûle. Choisissez votre camp."
5. Tester sur mobile et desktop

**Résultats attendus :**
- Marquee avec défilement continu fluide
- Traductions automatiques selon la langue sélectionnée
- Formulation française améliorée ("qualifiés" vs "montent")

## 📎 Liens associés

- **Issues liées** : N/A (amélioration directe)
- **Documentation** : [next-intl documentation](https://next-intl-docs.vercel.app/)
- **Autres PRs** : N/A

## 👥 Revue

- **Relecteurs suggérés** : @pylejeune @AlexLakarm
- **Domaines concernés** : SloganBanner component, i18n, UX/UI

## 🧪 Checklist

- [x] Le code compile sans erreur
- [x] Les tests unitaires passent
- [x] La documentation est à jour
- [x] Les dépendances sont à jour
- [x] La PR est prête pour la revue

## 📸 Captures d'écran (si applicable)

### Marquee en français
<img width="939" alt="image" src="https://github.com/user-attachments/assets/63f4f8d1-ad63-4aa8-b93c-11cd7131dfce" />

### Marquee en anglais  
<img width="932" alt="image" src="https://github.com/user-attachments/assets/56fc7c76-a592-4682-a0ae-6c87b36f2445" />

## 🗒️ Notes complémentaires

**Modifications apportées :**

1. **SloganBanner.tsx** :
   - Ajout de `useTranslations("SloganBanner")`
   - Remplacement du texte hardcodé par `t("before")`, `t("highlight")`, `t("after")`
   - Changement de `pauseOnHover={true}` à `pauseOnHover={false}`

2. **messages/en.json** :
   - Ajout de la section `SloganBanner` avec les textes anglais

3. **messages/fr.json** :
   - Ajout de la section `SloganBanner` avec les textes français
   - Utilisation de "qualifiés" au lieu de "montent" pour mieux refléter le processus de sélection

**Impact UX :**
- ✅ Expérience plus fluide sans interruption du marquee
- ✅ Support multilingue complet
- ✅ Meilleure compréhension du concept en français