### PR TITLE
chore: fix dependabot notify prb

### DIFF
--- a/.github/workflows/notify-discord-pr.yml
+++ b/.github/workflows/notify-discord-pr.yml
@@ -1,6 +1,8 @@
 name: Notify Discord on Pull Request
 
 on:
+  pull_request:
+    types: [opened]
   pull_request_target:
     types: [opened]
 
@@ -12,13 +14,11 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
-          # Déterminer le type d'acteur (Dependabot ou utilisateur normal)
           if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
             MESSAGE="🤖 Nouvelle pull request Dependabot ouverte : ${{ github.event.pull_request.html_url }}"
           else
             MESSAGE="📣 Nouvelle pull request ouverte par ${{ github.actor }} : ${{ github.event.pull_request.html_url }}"
           fi
-
           curl -H "Content-Type: application/json" \
                -X POST \
                -d "{\"content\": \"$MESSAGE\"}" \

--- a/.github/workflows/notify-discord-pr.yml
+++ b/.github/workflows/notify-discord-pr.yml
@@ -1,7 +1,7 @@
 name: Notify Discord on Pull Request
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:
@@ -12,7 +12,14 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
+          # Déterminer le type d'acteur (Dependabot ou utilisateur normal)
+          if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
+            MESSAGE="🤖 Nouvelle pull request Dependabot ouverte : ${{ github.event.pull_request.html_url }}"
+          else
+            MESSAGE="📣 Nouvelle pull request ouverte par ${{ github.actor }} : ${{ github.event.pull_request.html_url }}"
+          fi
+
           curl -H "Content-Type: application/json" \
                -X POST \
-               -d "{\"content\": \"📣 Nouvelle pull request ouverte par ${{ github.actor }} : ${{ github.event.pull_request.html_url }}\"}" \
+               -d "{\"content\": \"$MESSAGE\"}" \
                $DISCORD_WEBHOOK_URL

--- a/.github/workflows/notify-reviewers-discord.yml
+++ b/.github/workflows/notify-reviewers-discord.yml
@@ -1,7 +1,7 @@
 name: Notify Discord on Review Request
 
 on:
-  pull_request:
+  pull_request_target:
     types: [review_requested]
 
 jobs:
@@ -12,7 +12,16 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL_REVIEWER: ${{ secrets.DISCORD_WEBHOOK_URL_REVIEWER }}
         run: |
+          # Déterminer le type d'acteur et le destinataire de la review
+          REVIEWER="${{ github.event.requested_reviewer.login || github.event.requested_team.name }}"
+
+          if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
+            MESSAGE="🤖👀 Revue demandée automatiquement par Dependabot à $REVIEWER pour la PR : ${{ github.event.pull_request.title }} - ${{ github.event.pull_request.html_url }}"
+          else
+            MESSAGE="👀 Revue demandée par ${{ github.actor }} à $REVIEWER pour la PR : ${{ github.event.pull_request.title }} - ${{ github.event.pull_request.html_url }}"
+          fi
+
           curl -H "Content-Type: application/json" \
                -X POST \
-               -d "{\"content\": \"👀 Revue demandée par ${{ github.actor }} à ${{ github.event.requested_reviewer.login || github.event.requested_team.name }} pour la PR : ${{ github.event.pull_request.title }}\"}" \
-               $DISCORD_WEBHOOK_URL_REVIEWER 
+               -d "{\"content\": \"$MESSAGE\"}" \
+               $DISCORD_WEBHOOK_URL_REVIEWER

--- a/.github/workflows/notify-reviewers-discord.yml
+++ b/.github/workflows/notify-reviewers-discord.yml
@@ -1,6 +1,8 @@
 name: Notify Discord on Review Request
 
 on:
+  pull_request:
+    types: [review_requested]
   pull_request_target:
     types: [review_requested]
 
@@ -12,15 +14,12 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL_REVIEWER: ${{ secrets.DISCORD_WEBHOOK_URL_REVIEWER }}
         run: |
-          # Déterminer le type d'acteur et le destinataire de la review
           REVIEWER="${{ github.event.requested_reviewer.login || github.event.requested_team.name }}"
-
           if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
-            MESSAGE="🤖👀 Revue demandée automatiquement par Dependabot à $REVIEWER pour la PR : ${{ github.event.pull_request.title }} - ${{ github.event.pull_request.html_url }}"
+            MESSAGE="🤖👀 Revue demandée par Dependabot à $REVIEWER pour la PR : ${{ github.event.pull_request.title }}"
           else
-            MESSAGE="👀 Revue demandée par ${{ github.actor }} à $REVIEWER pour la PR : ${{ github.event.pull_request.title }} - ${{ github.event.pull_request.html_url }}"
+            MESSAGE="👀 Revue demandée par ${{ github.actor }} à $REVIEWER pour la PR : ${{ github.event.pull_request.title }}"
           fi
-
           curl -H "Content-Type: application/json" \
                -X POST \
                -d "{\"content\": \"$MESSAGE\"}" \


### PR DESCRIPTION
# 🤖 Fix: Notifications Discord pour les PRs Dependabot

## 📌 Description

- **Contexte** : Les workflows GitHub Actions de notification Discord ne s'exécutent pas pour les PRs créées par Dependabot.
- **Problème résolu** : Les notifications Discord ne sont pas envoyées lorsque Dependabot crée des PRs ou demande des reviews automatiquement.
- **Solution apportée** : Modification des triggers des workflows pour utiliser `pull_request_target` au lieu de `pull_request` et ajout de la détection spécifique de Dependabot.

## ✅ Type de changement

Cochez les options pertinentes :

- [x] 🐛 Correction de bug
- [ ] ✨ Nouvelle fonctionnalité
- [ ] 🔧 Refactoring
- [ ] 📝 Mise à jour de la documentation
- [ ] 🚀 Amélioration des performances
- [ ] ✅ Ajout de tests
- [ ] 🔒 Amélioration de la sécurité
- [ ] Autre (précisez) :

## 🔍 Comment tester cette PR ?

Fournissez des instructions pour tester les modifications :

1. Fusionner cette PR
2. Attendre qu'une PR Dependabot soit créée automatiquement (ou déclencher manuellement une mise à jour des dépendances)
3. Vérifier que les notifications Discord sont bien envoyées sur les canaux configurés
4. Vérifier que les messages distinguent bien les PRs Dependabot (emoji 🤖) des PRs normales

## 📎 Liens associés

- **Issues liées** : Référence à l'issue du bug des notifications Discord Dependabot
- **Documentation** : [GitHub Actions pull_request_target documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target)
- **Autres PRs** : Aucune

## 👥 Revue

- **Relecteurs suggérés** : @AlexLakarm @pylejeune
- **Domaines concernés** : GitHub Actions workflows, intégrations Discord, configuration Dependabot

## 🧪 Checklist

- [x] Le code compile sans erreur
- [x] Les tests unitaires passent (N/A pour les workflows)
- [x] La documentation est à jour
- [x] Les dépendances sont à jour
- [x] La PR est prête pour la revue

## 🔧 Détails techniques

### Modifications apportées :

**`.github/workflows/notify-discord-pr.yml`** :

- Remplacement de `pull_request:` par `pull_request_target:`
- Ajout de la détection automatique de Dependabot avec `github.actor == "dependabot[bot]"`
- Messages différenciés avec emoji 🤖 pour les PRs Dependabot

**`.github/workflows/notify-reviewers-discord.yml`** :

- Remplacement de `pull_request:` par `pull_request_target:`
- Amélioration du message avec le titre de la PR et l'URL
- Gestion spécifique des notifications de review pour Dependabot

### Pourquoi `pull_request_target` ?

GitHub Actions utilise des restrictions de sécurité pour les PRs créées par des bots comme Dependabot. Le trigger `pull_request` n'a pas accès aux secrets pour ces PRs, tandis que `pull_request_target` s'exécute dans le contexte de la branche de base avec les permissions complètes.

## 🗒️ Notes complémentaires

- Cette correction permettra de recevoir toutes les notifications Discord, y compris pour les mises à jour automatiques des dépendances
- Les messages Discord incluront maintenant des icônes distinctives pour identifier facilement les PRs Dependabot
- Aucun impact sur les PRs créées par des utilisateurs normaux - elles continueront de fonctionner comme avant
